### PR TITLE
more tag settings

### DIFF
--- a/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
+++ b/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
@@ -323,6 +323,7 @@ namespace Sdl.Community.ApplyStudioProjectTemplate
                         try
                         {
                             CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "SettingsTagVerifier", targetProject, null);
+                            CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "Settings", targetProject, null);
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
the original code line
CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "SettingsTagVerifier", targetProject, null);
only controls the state of the tag verification (enabled=true or false) but does not control the options "Tags added", "Deleted", "Order Change" and so on.

this is done with this setting bundle:
CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "Settings", targetProject, null);

Warning: with some tests on a own code, I suspect some interference with the term verifier settings. This should be checked