### PR TITLE
Reset settings if source settings not there

### DIFF
--- a/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
+++ b/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
@@ -512,6 +512,18 @@ namespace Sdl.Community.ApplyStudioProjectTemplate
                     }
                 }
             }
+            else
+            {
+                targetSettings.GetSettingsGroup(settingsGroupId).Reset();
+                if (targetLanguage == null)
+                {
+                    targetProject.UpdateSettings(targetSettings);
+                }
+                else
+                {
+                    targetProject.UpdateSettings(targetLanguage, targetSettings);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
In the copysettingsgroup function:
If a specific setting bundle is null or empty, this certainly mean that the standard settings have been set for the corresponding group. The settings of the target should be reseted rather than remained without changes.

I guess that the proofing of "targetlanguage" is necessary but I haven't tested it.