### PR TITLE
complete "overwrite term search settings"

### DIFF
--- a/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
+++ b/ApplyStudioProjectTemplate/Sdl.Community.ApplyStudioProjectTemplate/ApplyStudioProjectTemplateAction.cs
@@ -276,7 +276,8 @@ namespace Sdl.Community.ApplyStudioProjectTemplate
                         TermbaseConfiguration sourceTermbaseConfig = sourceProject.GetTermbaseConfiguration();
                         TermbaseConfiguration targetTermbaseConfig = targetProject.GetTermbaseConfiguration();
                         targetTermbaseConfig.TermRecognitionOptions = sourceTermbaseConfig.TermRecognitionOptions;
-
+                        CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "TermRecognitionSettings", targetProject, null);
+                        
                         // Updating with zero termbases throws an exception
                         if (targetTermbaseConfig.Termbases.Count > 0)
                         {


### PR DESCRIPTION
With this line
CopySettingsGroup(sourceSettingsBundle, targetSettingsBundle, "TermRecognitionSettings", targetProject, null);

the repetition threshold and the EnableTwoLetterTermRecognition box will be synchronized.