### PR TITLE
- Created a new service "AccessTokenService" to automatically recover…

### DIFF
--- a/IATETerminologyProvider/IATETerminologyProvider/Helpers/ApiUrls.cs
+++ b/IATETerminologyProvider/IATETerminologyProvider/Helpers/ApiUrls.cs
@@ -2,6 +2,16 @@
 {
 	public class ApiUrls
 	{
+		public static string GetAccessTokenUri(string userName, string password)
+		{
+			return @"https://iate.europa.eu/uac-api/auth/login?username=" + userName + "&password=" + password;
+		}
+
+		public static string GetExtendAccessTokenUri(string token)
+		{
+			return @"https://iate.europa.eu/uac-api/auth/token?refresh_token=" + token;
+		}
+
 		public static string BaseUri(string expand, string offset, string limit)
 		{
 			return @"https://iate.europa.eu/em-api/entries/_search?expand=" + expand + "&offset=" + offset + "&limit=" + limit;

--- a/IATETerminologyProvider/IATETerminologyProvider/IATETerminologyProvider.csproj
+++ b/IATETerminologyProvider/IATETerminologyProvider/IATETerminologyProvider.csproj
@@ -137,6 +137,7 @@
     <Compile Include="IATETerminologyProviderViewerWinFormsUI.cs" />
     <Compile Include="IATETerminologyProvider.cs" />
     <Compile Include="IATETerminologyProviderFactory.cs" />
+    <Compile Include="Model\ResponseModels\JsonAccessTokenModel.cs" />
     <Compile Include="Model\DocumentEntryState.cs" />
     <Compile Include="Model\DomainModel.cs" />
     <Compile Include="Model\EntryLanguageModel.cs" />
@@ -164,6 +165,7 @@
     <Compile Include="Properties\PluginProperties.cs" />
     <Compile Include="Service\DocumentStateService.cs" />
     <Compile Include="Service\DomainService.cs" />
+    <Compile Include="Service\AccessTokenService.cs" />
     <Compile Include="Service\PersistenceService.cs" />
     <Compile Include="Service\SegmentVisitor.cs" />
     <Compile Include="Service\SerializerService.cs" />
@@ -208,6 +210,7 @@
     <EmbeddedResource Include="PluginResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>PluginResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Ui\IATETermsControl.resx">
       <DependentUpon>IATETermsControl.cs</DependentUpon>

--- a/IATETerminologyProvider/IATETerminologyProvider/Model/ResponseModels/JsonAccessTokenModel.cs
+++ b/IATETerminologyProvider/IATETerminologyProvider/Model/ResponseModels/JsonAccessTokenModel.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace IATETerminologyProvider.Model.ResponseModels
+{
+	public class JsonAccessTokenModel
+	{
+		[JsonProperty("token_type")]
+		public string TokenType { get; set; }
+
+		public List<string> Tokens { get; set; }
+
+		[JsonProperty("refresh_token")]
+		public string RefreshToken { get; set; }
+	}
+}

--- a/IATETerminologyProvider/IATETerminologyProvider/PluginResources.Designer.cs
+++ b/IATETerminologyProvider/IATETerminologyProvider/PluginResources.Designer.cs
@@ -116,5 +116,23 @@ namespace IATETerminologyProvider {
                 return ResourceManager.GetString("Plugin_Name", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in refreshing the access token.
+        /// </summary>
+        internal static string TermSearchService_Error_in_refreshing_access_token {
+            get {
+                return ResourceManager.GetString("TermSearchService_Error_in_refreshing_access_token", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in requesting the access token.
+        /// </summary>
+        internal static string TermSearchService_Error_in_requesting_access_token {
+            get {
+                return ResourceManager.GetString("TermSearchService_Error_in_requesting_access_token", resourceCulture);
+            }
+        }
     }
 }

--- a/IATETerminologyProvider/IATETerminologyProvider/PluginResources.resx
+++ b/IATETerminologyProvider/IATETerminologyProvider/PluginResources.resx
@@ -136,4 +136,10 @@
   <data name="Plugin_Name" xml:space="preserve">
     <value>Sdl.Community.IATETerminologyProvider</value>
   </data>
+  <data name="TermSearchService_Error_in_requesting_access_token" xml:space="preserve">
+    <value>Error in requesting the access token</value>
+  </data>
+  <data name="TermSearchService_Error_in_refreshing_access_token" xml:space="preserve">
+    <value>Error in refreshing the access token</value>
+  </data>
 </root>

--- a/IATETerminologyProvider/IATETerminologyProvider/Service/AccessTokenService.cs
+++ b/IATETerminologyProvider/IATETerminologyProvider/Service/AccessTokenService.cs
@@ -1,0 +1,337 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using IATETerminologyProvider.Helpers;
+using IATETerminologyProvider.Model.ResponseModels;
+using Newtonsoft.Json;
+using RestSharp;
+
+namespace IATETerminologyProvider.Service
+{
+	public class AccessTokenService : INotifyPropertyChanged, IDisposable
+	{
+		private DateTime _requestedAccessToken;
+		private DateTime _extendedRefreshToken;
+
+		private bool _accessTokenExpired;
+		private bool _refreshTokenExpired;
+		private bool _accessTokenExtended;
+
+		private TimeSpan _accessTokenLifespan;
+		private TimeSpan _refreshTokenLifespan;
+
+		private string _accessToken;
+		private string _refreshToken;
+		private string _userName;
+		private string _password;
+
+		private readonly DispatcherTimer _timer;
+
+		public AccessTokenService(TimeSpan accessTokenLifespan, TimeSpan refreshTokenLifespan)
+		{
+			Reset();
+
+			_accessTokenLifespan = accessTokenLifespan.TotalSeconds > 0 ? accessTokenLifespan : new TimeSpan(0, 3, 0, 0);
+			_refreshTokenLifespan = refreshTokenLifespan.TotalSeconds > 0 ? refreshTokenLifespan : new TimeSpan(0, 12, 0, 0);
+
+			_timer = new DispatcherTimer
+			{
+				Interval = TimeSpan.FromMilliseconds(1000)
+			};
+			_timer.Tick += Timer_Tick;
+			_timer.Start();
+		}
+
+		public AccessTokenService() : this(new TimeSpan(0), new TimeSpan(0)) { }
+
+		public bool GetAccessToken(string userName, string password)
+		{
+			if (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password))
+			{
+				return false;
+			}
+
+			Reset();
+
+			_userName = userName;
+			_password = password;
+
+			var response = GetAccessTokenResponse(userName, password);
+			if (response != null && response.Tokens.Count > 0)
+			{
+				_accessToken = response.Tokens[0];
+				_refreshToken = response.RefreshToken;
+
+				_accessTokenExpired = false;
+				_accessTokenExtended = false;
+				_refreshTokenExpired = false;
+
+				_requestedAccessToken = DateTime.Now;
+				_extendedRefreshToken = DateTime.MinValue;
+
+				OnPropertyChanged(nameof(AccessToken));
+				OnPropertyChanged(nameof(RequestedAccessToken));
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public bool GetAccessToken()
+		{
+			return GetAccessToken("SDL_PLUGIN", "E9KWtWahXs4hvE9z");
+		}
+
+		public bool ExtendAccessToken()
+		{
+			if (_accessTokenExtended || string.IsNullOrEmpty(_accessToken) ||
+				string.IsNullOrEmpty(RefreshToken) || _requestedAccessToken == DateTime.MinValue)
+			{
+				return false;
+			}
+
+			var response = GetExtendAccessTokenResponse();
+			if (response != null && response.Tokens.Count > 0)
+			{
+				_accessToken = response.Tokens[0];
+				_refreshToken = response.RefreshToken;
+
+				_accessTokenExpired = true;
+				_accessTokenExtended = true;
+				_refreshTokenExpired = false;
+
+				_extendedRefreshToken = DateTime.Now;
+
+				OnPropertyChanged(nameof(ExtendedRefreshToken));
+
+				return true;
+			}
+
+			return true;
+		}
+
+		public bool AccessTokenExpired
+		{
+			get { return _accessTokenExpired; }
+			private set
+			{
+				if (_accessTokenExpired == value)
+				{
+					return;
+				}
+
+				_accessTokenExpired = value;
+				OnPropertyChanged(nameof(AccessTokenExpired));
+			}
+		}
+
+		public bool RefreshTokenExpired
+		{
+			get { return _refreshTokenExpired; }
+			private set
+			{
+				if (_refreshTokenExpired == value)
+				{
+					return;
+				}
+
+				_refreshTokenExpired = value;
+				OnPropertyChanged(nameof(RefreshTokenExpired));
+			}
+		}
+
+		public bool AccessTokenExtended
+		{
+			get { return _accessTokenExtended; }
+			private set
+			{
+				if (_accessTokenExtended == value)
+				{
+					return;
+				}
+
+				_accessTokenExtended = value;
+				OnPropertyChanged(nameof(AccessTokenExtended));
+			}
+		}
+
+		public string AccessToken
+		{
+			get { return _accessToken; }
+			private set
+			{
+				if (_accessToken == value)
+				{
+					return;
+				}
+
+				_accessToken = value;
+				OnPropertyChanged(nameof(AccessToken));
+			}
+		}
+
+		public string RefreshToken
+		{
+			get { return _refreshToken; }
+			private set
+			{
+				if (_refreshToken == value)
+				{
+					return;
+				}
+
+				_refreshToken = value;
+				OnPropertyChanged(nameof(RefreshToken));
+			}
+		}
+
+		public DateTime RequestedAccessToken
+		{
+			get { return _requestedAccessToken; }
+			private set
+			{
+				if (_requestedAccessToken == value)
+				{
+					return;
+				}
+
+				_requestedAccessToken = value;
+				OnPropertyChanged(nameof(RequestedAccessToken));
+			}
+		}
+
+		public DateTime ExtendedRefreshToken
+		{
+			get { return _extendedRefreshToken; }
+			private set
+			{
+				if (_extendedRefreshToken == value)
+				{
+					return;
+				}
+
+				_extendedRefreshToken = value;
+				OnPropertyChanged(nameof(ExtendedRefreshToken));
+			}
+		}
+
+		public TimeSpan AccessTokenLifespan
+		{
+			get { return _accessTokenLifespan; }
+			private set
+			{
+				if (_accessTokenLifespan == value)
+				{
+					return;
+				}
+
+				_accessTokenLifespan = value;
+				OnPropertyChanged(nameof(AccessTokenLifespan));
+			}
+		}
+
+		public TimeSpan RefreshTokenLifespan
+		{
+			get { return _refreshTokenLifespan; }
+			private set
+			{
+				if (_refreshTokenLifespan == value)
+				{
+					return;
+				}
+
+				_refreshTokenLifespan = value;
+				OnPropertyChanged(nameof(RefreshTokenLifespan));
+			}
+		}
+
+		private JsonAccessTokenModel GetAccessTokenResponse(string userName, string password)
+		{
+			var client = new RestClient(ApiUrls.GetAccessTokenUri(userName, password));
+			return GetResponse(client);
+		}
+
+		private JsonAccessTokenModel GetExtendAccessTokenResponse()
+		{
+			var client = new RestClient(ApiUrls.GetExtendAccessTokenUri(RefreshToken));
+			return GetResponse(client);
+		}
+
+		private static JsonAccessTokenModel GetResponse(IRestClient client)
+		{
+			var request = new RestRequest("", Method.GET);
+			request.AddHeader("Connection", "Keep-Alive");
+			request.AddHeader("Cache-Control", "no-cache");
+			request.AddHeader("Pragma", "no-cache");
+			request.AddHeader("Accept", "application/json");
+			request.AddHeader("Accept-Encoding", "gzip, deflate, br");
+			request.AddHeader("Content-Type", "application/json");
+			request.AddHeader("Origin", "https://iate.europa.eu");
+			request.AddHeader("Host", "iate.europa.eu");
+			request.AddHeader("Access-Control-Allow-Origin", "*");
+
+			var response = client.Execute(request);
+
+			var accessTokenRespose = JsonConvert.DeserializeObject<JsonAccessTokenModel>(response.Content);
+			return accessTokenRespose;
+		}
+
+		private void Reset()
+		{
+			_accessTokenExpired = false;
+			_accessTokenExtended = false;
+			_refreshTokenExpired = false;
+
+			_accessToken = string.Empty;
+			_refreshToken = string.Empty;
+
+			_requestedAccessToken = DateTime.MinValue;
+			_extendedRefreshToken = DateTime.MinValue;
+
+			_userName = string.Empty;
+			_password = string.Empty;
+		}
+
+		private void Timer_Tick(object sender, System.EventArgs e)
+		{
+			if (!_accessTokenExpired && _requestedAccessToken > DateTime.MinValue)
+			{
+				var expireTime = _requestedAccessToken.AddSeconds(_accessTokenLifespan.TotalSeconds);
+				if (expireTime < DateTime.Now.AddMinutes(1))
+				{
+					_accessTokenExpired = true;
+				}
+			}
+			else if (!_refreshTokenExpired && _extendedRefreshToken > DateTime.MinValue)
+			{
+				var expireTime = _extendedRefreshToken.AddSeconds(_refreshTokenLifespan.TotalSeconds);
+				if (expireTime < DateTime.Now.AddMinutes(1))
+				{
+					_refreshTokenExpired = true;
+				}
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public void Dispose()
+		{
+			if (_timer != null)
+			{
+				_timer.Tick -= Timer_Tick;
+			}
+		}
+	}
+}


### PR DESCRIPTION
… the authorization "Access token" that is now added to the header for call (search) to the IATE terminology service.

The service will also identify when the token as expired and attempt to extend (by way of refreshing) the token for an additional 9hrs.
Note: If the total time allowed for the access token as elapsed (i.e. > 12 hours) and the project has been open for that same period of time, then an exception is thrown indicating an error in refreshing the access token.