### PR TITLE
IATETerminologyProvider_2019 2.6.3.0 -> 2.6.3.1

### DIFF
--- a/IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest.xml
+++ b/IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest.xml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>IATETerminologyProvider</PlugInName>
-  <Version>2.6.3.0</Version>
+  <Version>2.6.3.1</Version>
   <Description>Integration with IATE European Union terminology</Description>
   <Author>SDL Community Developers</Author>
 	<Include>
 		<File>Newtonsoft.Json.dll</File>
 		<File>RestSharp.dll</File>
+		<File>NLog.dll</File>
 	</Include>
   <RequiredProduct name="SDLTradosStudio" minversion="15.0"/>
 </PluginPackage>


### PR DESCRIPTION
 - adds reference to NLog in pluginpackage