### PR TITLE
Preserve whitespace in Transit Projects

### DIFF
--- a/StarTransit/Sdl.Community.StarTransit.Shared/Import/TransitParser.cs
+++ b/StarTransit/Sdl.Community.StarTransit.Shared/Import/TransitParser.cs
@@ -37,7 +37,9 @@ namespace Sdl.Community.StarTransit.Shared.Import
         {
             OnProgress(0);
             _document = new XmlDocument();
+			_document.PreserveWhitespace = true;
             _srcDocument = new XmlDocument();
+			_srcDocument.PreserveWhitespace = true;
             string trgFilePath = _fileProperties.FileConversionProperties.OriginalFilePath;
             _document.Load(trgFilePath);
 
@@ -256,6 +258,11 @@ namespace Sdl.Community.StarTransit.Shared.Import
 					if (item.NodeType == XmlNodeType.Element)
 					{
 						segment.Add(CreatePhTag(item.Name, item, source));
+					}
+
+					if (item.NodeType == XmlNodeType.Whitespace)
+					{
+						segment.Add(CreateText(" "));
 					}
 				}
 			}

--- a/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/PackageDetailsViewModel.cs
+++ b/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/PackageDetailsViewModel.cs
@@ -295,7 +295,7 @@ namespace Sdl.Community.StarTransit.UI.ViewModels
                 if (columnName == "Template" && Template==null)
                 {
                     
-                        return "Template is rquired";
+                        return "Template is required";
                    
                 }
                 if (columnName == "SelectedHour" && SelectedHour == -1)


### PR DESCRIPTION
Fixes issue #314

Transit files require to preserve their whitespaces, otherwise words are accidentally concatenated.
Also fixed a typo in the interface.