### PR TITLE
Logging failed http requests to DeepL Translate REST API endpoint

### DIFF
--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
@@ -86,7 +86,9 @@ namespace Sdl.Community.DeepLMTProvider
 					}
 					else
 					{
-						MessageBox.Show(response.ReasonPhrase, string.Empty, MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                        Log.Logger.Error($"HTTP Request to DeepL Translate REST API endpoint failed with status code '{response.StatusCode}'. " +
+                            $"Response content: {response.Content?.ReadAsStringAsync().Result}.");
+                        MessageBox.Show(response.ReasonPhrase, string.Empty, MessageBoxButton.OK, MessageBoxImage.Exclamation);
 					}
 				}
 			}


### PR DESCRIPTION
This is useful in case of using DeepL Provider in standalone plugin.