### PR TITLE
SdlXliff Toolkit 4.1.3.0 -> 4.1.4.0

### DIFF
--- a/Toolkit/SDLXLIFFSliceOrChange/ReplaceManager.cs
+++ b/Toolkit/SDLXLIFFSliceOrChange/ReplaceManager.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Xml;
 using log4net;
 //using Sdl.Utilities.BatchSearchReplace.Lib;
@@ -175,7 +177,7 @@ namespace SDLXLIFFSliceOrChange
 
         private static void ReplaceTheVaue(ReplaceSettings settings, bool inSource, XmlElement child)
         {
-            var segmentHtml = child.InnerXml;
+			var segmentHtml = child.InnerXml;
             
             if (settings.UseRegEx)
             {

--- a/Toolkit/SDLXLIFFSliceOrChange/ReplaceSettings.cs
+++ b/Toolkit/SDLXLIFFSliceOrChange/ReplaceSettings.cs
@@ -1,15 +1,40 @@
 ﻿using System;
+using System.Net;
 
 namespace SDLXLIFFSliceOrChange
 {
     public class ReplaceSettings
     {
-        public String SourceSearchText { get; set; }
-        public String SourceReplaceText { get; set; }
-        public String TargetSearchText { get; set; }
-        public String TargetReplaceText { get; set; }
+	    private string _sourceSearchText;
+	    private string _sourceReplaceText;
+	    private string _targetSearchText;
+	    private string _targetReplaceText;
 
-        public bool MatchCase { get; set; }
+	    public string SourceSearchText
+	    {
+		    get => _sourceSearchText;
+		    set { _sourceSearchText = WebUtility.HtmlEncode(value); }
+	    }
+
+	    public string SourceReplaceText
+	    {
+		    get => _sourceReplaceText;
+		    set { _sourceReplaceText = WebUtility.HtmlEncode(value); }
+	    }
+
+	    public string TargetSearchText
+	    {
+		    get => _targetSearchText;
+		    set { _targetSearchText = WebUtility.HtmlEncode(value); }
+	    }
+
+	    public string TargetReplaceText
+	    {
+		    get => _targetReplaceText;
+		    set { _targetReplaceText = WebUtility.HtmlEncode(value); }
+	    }
+
+	    public bool MatchCase { get; set; }
         public bool MatchWholeWord { get; set; }
         public bool UseRegEx { get; set; }
     }

--- a/Toolkit/SdlXliffToolkit/pluginpackage.manifest.xml
+++ b/Toolkit/SdlXliffToolkit/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDLXLIFF Toolkit</PlugInName>
-  <Version>4.1.3.0</Version>
+  <Version>4.1.4.0</Version>
   <Description>SdlXliffToolkit</Description>
 	<Author>SDL Community Developers</Author>
   <Include>


### PR DESCRIPTION
 - fixes Search and Replace issue by html encoding the search and replace texts