### PR TITLE
[StarTransit] Machine Translation handling (Branch)

### DIFF
--- a/StarTransit/Sdl.Community.StarTransit.Shared/Models/PackageModel.cs
+++ b/StarTransit/Sdl.Community.StarTransit.Shared/Models/PackageModel.cs
@@ -17,5 +17,6 @@ namespace Sdl.Community.StarTransit.Shared.Models
         public List<LanguagePair> LanguagePairs { get; set; }
         public string PathToPrjFile { get; set; }
 		public Dictionary<string,int> TMPenalties { get; set; }
+		public List<string> MachineTransMem { get; set; }
 	}
 }

--- a/StarTransit/Sdl.Community.StarTransit.Shared/Services/ProjectService.cs
+++ b/StarTransit/Sdl.Community.StarTransit.Shared/Services/ProjectService.cs
@@ -79,7 +79,7 @@ namespace Sdl.Community.StarTransit.Shared.Services
 				}
 
 				// Remove Machine Translation memories from pair.StarTranslationMemoryMetadatas, if the user requests them, they will be imported separately, but never in the main TM
-				pair.StarTranslationMemoryMetadatas.RemoveAll(item => Path.GetFileName(item.TargetFile).Contains("_MT_"));
+				pair.StarTranslationMemoryMetadatas.RemoveAll(item => Path.GetFileName(item.TargetFile).Contains("_AEXTR_MT_"));
 
 				// Remove found items from pair.StarTranslationMemoryMetadatas (the remained ones are those which do not have penalties set on them)
 				foreach (var item in penaltiesTmsList)

--- a/StarTransit/Sdl.Community.StarTransit.UI/Controls/TranslationMemories.xaml
+++ b/StarTransit/Sdl.Community.StarTransit.UI/Controls/TranslationMemories.xaml
@@ -7,35 +7,35 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
     <UserControl.Resources>
-	    <ResourceDictionary>
+        <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-	            <ResourceDictionary>
-		            <Style x:Key="NavigationButtonStyle" TargetType="{x:Type ListViewItem}">
-			            <Setter Property="Foreground" Value="#FF0B6266" />
-			            <Setter Property="FontSize" Value="18.667" />
-			            <Setter Property="HorizontalAlignment" Value="Left" />
-			            <Setter Property="Cursor" Value="Hand" />
-			            <Setter Property="Margin" Value="10,10,0,0" />
-			            <Setter Property="Background" Value="Transparent" />
-			            <Setter Property="Template">
-				            <Setter.Value>
-					            <ControlTemplate TargetType="{x:Type ListViewItem}">
-						            <ContentPresenter/>
-					            </ControlTemplate>
-				            </Setter.Value>
-			            </Setter>
-			            <Style.Triggers>
-				            <Trigger Property="IsSelected" Value="true">
-					            <Setter Property="Foreground" Value="#3EA691" />
-				            </Trigger>
-			            </Style.Triggers>
-		            </Style>
-					</ResourceDictionary>
-				<ResourceDictionary Source="..\UIHelpers\MetroStyle.xaml"/>
-	            <ResourceDictionary Source="..\UIHelpers\ButtonsStyle.xaml"/>
+                <ResourceDictionary>
+                    <Style x:Key="NavigationButtonStyle" TargetType="{x:Type ListViewItem}">
+                        <Setter Property="Foreground" Value="#FF0B6266" />
+                        <Setter Property="FontSize" Value="18.667" />
+                        <Setter Property="HorizontalAlignment" Value="Left" />
+                        <Setter Property="Cursor" Value="Hand" />
+                        <Setter Property="Margin" Value="10,10,0,0" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                    <ContentPresenter/>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected" Value="true">
+                                <Setter Property="Foreground" Value="#3EA691" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
+                <ResourceDictionary Source="..\UIHelpers\MetroStyle.xaml"/>
+                <ResourceDictionary Source="..\UIHelpers\ButtonsStyle.xaml"/>
             </ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
-	</UserControl.Resources>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="1*" />
@@ -79,14 +79,17 @@
                         <ColumnDefinition Width="1*"/>
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Title}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10,10,0,0" FontSize="13" FontWeight="DemiBold"></TextBlock>
-					<StackPanel Grid.Row="1" Margin="20,20,0,0"  Grid.Column="0">
-						<RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="None" Content="None" GroupName="1" IsChecked="{Binding IsNoneChecked}"  Command="{Binding SetBtnNameCommand}"/>
-						<RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="Create"  Content="Create TM" GroupName="1"  IsChecked="{Binding IsCreateChecked}"  Command="{Binding SetBtnNameCommand}"/>
-						<RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="Browse"  Content="Browse TM" GroupName="1" IsChecked="{Binding IsBrowseChecked}"  Command="{Binding SetBtnNameCommand}"/>
+                    <StackPanel Grid.Row="1" Margin="20,20,0,0"  Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Left" Width="373">
+                        <RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="None" Content="None" GroupName="1" IsChecked="{Binding IsNoneChecked}"  Command="{Binding SetBtnNameCommand}"/>
+                        <StackPanel Orientation="Horizontal">
+                            <RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="Create"  Content="Create TM" GroupName="1"  IsChecked="{Binding IsCreateChecked}"  Command="{Binding SetBtnNameCommand}"/>
+							<CheckBox Style="{DynamicResource MetroCheckBox}" Content="Import machine translation" ToolTip="Imports any existing Machine Translation generated by Transit into a separate Translation Memory" IsChecked="{Binding IsImportMTChecked}" Command="{Binding ImportMTCommand}" Visibility="{Binding ImportMTVisible}" Margin="20,0,0,0"/>
+                        </StackPanel>
+                        <RadioButton Style="{DynamicResource MetroRadioButton}" Margin="0,5,0,0" x:Name="Browse"  Content="Browse TM" GroupName="1" IsChecked="{Binding IsBrowseChecked}"  Command="{Binding SetBtnNameCommand}"/>
                     </StackPanel>
                     <Button Style="{DynamicResource StudioGreenButtonsStyle}" x:Name="CreateTmButton" Command="{Binding Command}" Content="{Binding ButtonName}" Grid.Row="1" Grid.Column="1"
-							Width="auto" Height="auto" Margin="0,50,123,0" Visibility="{Binding Visibility}" Background="#FF3EA691" BorderBrush="#FF3EA691" Foreground="White">						
-					</Button>
+							Width="auto" Height="auto" Margin="0,50,123,0" Visibility="{Binding Visibility}" Background="#FF3EA691" BorderBrush="#FF3EA691" Foreground="White">
+                    </Button>
                     <TextBlock Grid.Column="0" Grid.Row="2" Text="TM name:" Margin="20,15,22,15"/>
                     <TextBox Style="{DynamicResource MetroTextBox}"
 						Controls:TextBoxHelper.ClearTextButton="True"                

--- a/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesPenaltiesViewModel.cs
+++ b/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesPenaltiesViewModel.cs
@@ -125,7 +125,7 @@ namespace Sdl.Community.StarTransit.UI.ViewModels
 					{
 						foreach (var filePath in langPair.StarTranslationMemoryMetadatas)
 						{
-							if (!filePath.TargetFile.Contains("_MT_")){
+							if (!filePath.TargetFile.Contains("_AEXTR_MT_")){
 								TranslationMemoryName = Path.GetFileName(filePath.TargetFile);
 								TranslationMemoryPath = filePath.TargetFile;
 

--- a/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesPenaltiesViewModel.cs
+++ b/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesPenaltiesViewModel.cs
@@ -125,17 +125,19 @@ namespace Sdl.Community.StarTransit.UI.ViewModels
 					{
 						foreach (var filePath in langPair.StarTranslationMemoryMetadatas)
 						{
-							TranslationMemoryName = Path.GetFileName(filePath.TargetFile);
-							TranslationMemoryPath = filePath.TargetFile;
+							if (!filePath.TargetFile.Contains("_MT_")){
+								TranslationMemoryName = Path.GetFileName(filePath.TargetFile);
+								TranslationMemoryPath = filePath.TargetFile;
 
-							var translationMemoriesPenaltiesModel = new TranslationMemoriesPenaltiesModel()
-							{
-								TranslationMemoryName = TranslationMemoryName,
-								TranslationMemoryPath = TranslationMemoryPath,
-								TMPenalty = TMPenalty
-							};
-							
-							TranslationMemoriesPenaltiesModelList.Add(translationMemoriesPenaltiesModel);
+								var translationMemoriesPenaltiesModel = new TranslationMemoriesPenaltiesModel()
+								{
+									TranslationMemoryName = TranslationMemoryName,
+									TranslationMemoryPath = TranslationMemoryPath,
+									TMPenalty = TMPenalty
+								};
+
+								TranslationMemoriesPenaltiesModelList.Add(translationMemoriesPenaltiesModel);
+							}
 						}
 					}
 				}

--- a/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesViewModel.cs
+++ b/StarTransit/Sdl.Community.StarTransit.UI/ViewModels/TranslationMemoriesViewModel.cs
@@ -298,7 +298,7 @@ namespace Sdl.Community.StarTransit.UI.ViewModels
 
 				foreach (var filePath in SelectedItem.StarTranslationMemoryMetadatas)
 				{
-					if (Path.GetFileName(filePath.TargetFile).Contains("_MT_"))
+					if (Path.GetFileName(filePath.TargetFile).Contains("_AEXTR_MT_"))
 						_package.MachineTransMem.Add(filePath.TargetFile);
 				}
 			}


### PR DESCRIPTION
Machine translation reference material is no longer imported by default into a TM.
Users can now choose if they want this machine translation material to be imported or not. If they choose to import it, it will be saved into an additional translation memory with a penalty of -1 so that it's not used for pre-translation and can't end up in the main translation memory when running "Update main translations memories".