### PR TITLE
SDL MT Cloud: Initialize Rating controller after we load the settings…

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/InvertableBoolEnabledConverter.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/InvertableBoolEnabledConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Sdl.Community.MTCloud.Provider.Converters
+{
+	public class InvertableBoolEnabledConverter : IValueConverter
+	{
+		enum Parameters
+		{
+			Inverted
+		}
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var boolValue = value != null && (bool)value;
+			if (parameter == null) return boolValue;
+			var direction = (Parameters)Enum.Parse(typeof(Parameters), (string)parameter);
+			if (direction == Parameters.Inverted)
+				return !boolValue;
+			return boolValue;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return null;
+		}
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Interfaces/IRatingService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Interfaces/IRatingService.cs
@@ -7,5 +7,6 @@
 		void SetRateOptionFromShortcuts(string optionName);
 		void SetOptionTooltip(string optionName, string tooltip);
 		void SetTranslationService(ITranslationService transaltionService);
+		void SetSendFeedback(bool sendFeedback);
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/FeedbackOption.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/FeedbackOption.cs
@@ -7,6 +7,7 @@ namespace Sdl.Community.MTCloud.Provider.Model
 		private bool _isChecked;
 		private string _studioActionId;
 		private string _tooltip;
+		private bool _isEnabled;
 
 		public bool IsChecked
 		{
@@ -18,6 +19,17 @@ namespace Sdl.Community.MTCloud.Provider.Model
 				OnPropertyChanged(nameof(IsChecked));
 			}
 		}
+		//public bool IsEnabled
+		//{
+		//	get => _isEnabled;
+		//	set
+		//	{
+		//		if (_isEnabled == value) return;
+		//		_isEnabled = value;
+		//		OnPropertyChanged(nameof(IsEnabled));
+		//	}
+		//}
+
 		public string StudioActionId
 		{
 			get => _studioActionId;

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.Designer.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.Designer.cs
@@ -463,6 +463,15 @@ namespace Sdl.Community.MTCloud.Provider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable &quot;Send feedback option&quot; from Settings.
+        /// </summary>
+        public static string RateIt_Option_DisabledMessage {
+            get {
+                return ResourceManager.GetString("RateIt_Option_DisabledMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Grammar.
         /// </summary>
         public static string RateIt_Option_Grammar {

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.resx
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.resx
@@ -328,4 +328,7 @@
   <data name="SettingsWindow_ReSendTransaltionOption" xml:space="preserve">
     <value>Re-send draft and translated segments</value>
   </data>
+  <data name="RateIt_Option_DisabledMessage" xml:space="preserve">
+    <value>Enable "Send feedback option" from Settings</value>
+  </data>
 </root>

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Controls\ToolWindowsControl.xaml.cs">
       <DependentUpon>ToolWindowsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converters\InvertableBoolEnabledConverter.cs" />
     <Compile Include="Extensions\WindowsControlUtils.cs" />
     <Compile Include="Helpers\TaskUtilities.cs" />
     <Compile Include="Interfaces\IActionProvider.cs" />

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/RateItController.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/RateItController.cs
@@ -5,7 +5,6 @@ using Sdl.Community.MTCloud.Provider.Interfaces;
 using Sdl.Desktop.IntegrationApi;
 using Sdl.Desktop.IntegrationApi.Extensions;
 using Sdl.TranslationStudioAutomation.IntegrationApi;
-using Application = System.Windows.Forms.Application;
 
 namespace Sdl.Community.MTCloud.Provider.Studio
 {
@@ -28,15 +27,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 
 		protected override Control GetContentControl()
 		{
-			//var parent = _control.Value.Controls.Owner.Parent;
-			//var form = parent as Form;
-			//var parent = cont.Get
-			//foreach (Window window in Application.OpenForms)
-			//{
-			//	Console.WriteLine(window.Title);
-			//}
 			return _control.Value;
-
 		}
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/View/RateItView.xaml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/View/RateItView.xaml
@@ -6,6 +6,7 @@
              xmlns:viewModel="clr-namespace:Sdl.Community.MTCloud.Provider.ViewModel"
              xmlns:sdl="http://schemas.sdl.com/xaml"
 			 xmlns:rsx ="clr-namespace:Sdl.Community.MTCloud.Provider"
+			 xmlns:converters ="clr-namespace:Sdl.Community.MTCloud.Provider.Converters"
              xmlns:watermarkTextBox="clr-namespace:Sdl.Desktop.Platform.Controls.Controls.WatermarkTextBox;assembly=Sdl.Desktop.Platform.Controls"
 			 d:DataContext="{d:DesignInstance viewModel:RateItViewModel}"
              mc:Ignorable="d" 
@@ -20,9 +21,11 @@
 				<ResourceDictionary Source="/Sdl.Desktop.Platform.Controls;component/Controls/WatermarkTextBox/WatermarkTextBoxResources.xaml"/>
 				<ResourceDictionary Source="../Styles/General.xaml"/>
 			</ResourceDictionary.MergedDictionaries>
+			<converters:InvertableBoolEnabledConverter x:Key="InvertableBoolEnabledConverter"/>
 			<Style TargetType="CheckBox" x:Key="OptionsCheckboxesStyle" BasedOn="{StaticResource Sdl.Checkbox.GenericStyle}">
 				<Setter Property="Margin" Value="10,0,5,10"/>
 			</Style>
+
 		</ResourceDictionary>
 	</UserControl.Resources>
 	<ScrollViewer VerticalScrollBarVisibility="Auto" 
@@ -37,49 +40,59 @@
 				<ColumnDefinition Width="Auto"/>
 			</Grid.ColumnDefinitions>
 			<WrapPanel Grid.Row="0" Margin="0,10,0,0" Grid.Column="0" ItemWidth="170">
+				
+				<!--<ListBox> TODO: Transform the checkboxes into a listbox with an array of checkboxes					
+				</ListBox>-->
 				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_WordsOmission}"
-					  IsChecked="{Binding WordsOmissionOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
-					<CheckBox.ToolTip>
+					  IsChecked="{Binding WordsOmissionOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+					  IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
+					<CheckBox.ToolTip>  <!--TODO: If the option is disabled change te text message (Confirm exact text): "To enable rating change the settings..."-->
 						<ToolTip Content="{Binding WordsOmissionOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				
-				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Grammar}"
-			          IsChecked="{Binding GrammarOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Grammar}" 
+						  IsChecked="{Binding GrammarOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding GrammarOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				
 				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Unintelligence}"
-	                   IsChecked="{Binding UnintelligenceOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+						  IsChecked="{Binding UnintelligenceOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding UnintelligenceOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				
-				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_WordChoice}"
-	                   IsChecked="{Binding WordChoiceOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_WordChoice}" 
+						  IsChecked="{Binding WordChoiceOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding WordChoiceOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				
-				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_WordsAddition}"
-						 IsChecked="{Binding WordsAdditionOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_WordsAddition}" 
+						  IsChecked="{Binding WordsAdditionOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding WordsAdditionOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				
-				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Spelling}"
-	                   IsChecked="{Binding SpellingOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Spelling}" 
+						  IsChecked="{Binding SpellingOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding SpellingOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
 				</CheckBox>
 				<CheckBox Style="{StaticResource OptionsCheckboxesStyle}" Content="{x:Static rsx:PluginResources.RateIt_Option_Capitalization}"
-	                   IsChecked="{Binding CapitalizationOption.IsChecked,UpdateSourceTrigger=PropertyChanged}">
+						  IsChecked="{Binding CapitalizationOption.IsChecked,UpdateSourceTrigger=PropertyChanged}" ToolTipService.ShowOnDisabled="True"
+				          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}">
 					<CheckBox.ToolTip>
 						<ToolTip Content="{Binding CapitalizationOption.Tooltip,UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ToolTipStyle}"/>
 					</CheckBox.ToolTip>
@@ -87,7 +100,8 @@
 			</WrapPanel>
 			
 			<sdl:RateItControl Grid.Row="0" Grid.Column="1" BorderThickness="0"
-			                   Rating="{Binding Rating}" EnableMouseHoverSelection="False" VerticalAlignment="Top" 
+			                   Rating="{Binding Rating}" EnableMouseHoverSelection="False" VerticalAlignment="Top"
+			                   IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}"
 							   Height="40"
 							   ImageHeight="15"
 							   Width="130"
@@ -95,8 +109,10 @@
 			                   />			
 			<TextBox  Style="{DynamicResource WatermarkTextBox}" watermarkTextBox:TextBoxWatermarkHelper.WatermarkText ="{x:Static rsx:PluginResources.RateIt_FeedbackWatermark}"
 					  Grid.Row="1" Grid.Column="0" MaxLines="3" Text="{Binding Feedback,UpdateSourceTrigger=PropertyChanged}" Margin="10,0,0,0"
-					 VerticalContentAlignment="Center" TextWrapping="Wrap" AcceptsReturn="True"/>
-			<Button Grid.Row="1" Grid.Column="1" Style="{StaticResource Sdl.Button.WindowControlStyle}" Margin="5" 
+					  VerticalContentAlignment="Center" TextWrapping="Wrap" AcceptsReturn="True"
+			          IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}"/>
+			<Button Grid.Row="1" Grid.Column="1" Style="{StaticResource Sdl.Button.WindowControlStyle}" Margin="5"
+			        IsEnabled="{Binding SendFeedback,UpdateSourceTrigger=PropertyChanged,Converter={StaticResource InvertableBoolEnabledConverter}}"
 					Cursor="Hand" Content="{x:Static rsx:PluginResources.RateIt_FeedbackBtn}" Command="{Binding SendFeedbackCommand}"/>
 		</Grid>
 	</ScrollViewer>

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Sdl.Community.MTCloud.Languages.Provider;
@@ -16,6 +17,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 		private readonly IActionProvider _actionProvider;
 		private readonly List<ISDLMTCloudAction> _actions;
 		private ICommand _sendFeedbackCommand;
+		private ObservableCollection<FeedbackOption> _feedbackOptions;
 
 		private FeedbackOption _wordsOmissionChecked;
 		private FeedbackOption _grammarChecked;
@@ -26,13 +28,15 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 		private FeedbackOption _capitalizationChecked;
 		private int _rating;
 		private string _feedback;
+		private bool _sendFeedback;
 
 		public RateItViewModel(IShortcutService shortcutService,IActionProvider actionProvider)
 		{
 			_actionProvider = actionProvider;
 			SetShortcutService(shortcutService);
 			InitializeFeedbackOptions();
-
+			//_feedbackOptions = new ObservableCollection<FeedbackOption>(
+			//	);
 			ClearCommand = new CommandHandler(ClearFeedbackBox);
 
 			_actions = InitializeActions();
@@ -129,6 +133,17 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			}
 		}
 
+		public bool SendFeedback
+		{
+			get => _sendFeedback;
+			set
+			{
+				if (_sendFeedback == value) return;
+				_sendFeedback = value;
+				OnPropertyChanged(nameof(SendFeedback));
+			}
+		}
+
 		public string Feedback
 		{
 			get => _feedback;
@@ -141,7 +156,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 		}
 
 		public ICommand ClearCommand { get; }
-		public ICommand SendFeedbackCommand => _sendFeedbackCommand ?? (_sendFeedbackCommand = new AsyncCommand(SendFeedback));
+		public ICommand SendFeedbackCommand => _sendFeedbackCommand ?? (_sendFeedbackCommand = new AsyncCommand(SendFeedbackToService));
 
 
 		public void IncreaseRating()
@@ -183,7 +198,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			propertyInfo.SetValue(this, option);
 		}
 
-		private async Task SendFeedback()
+		private async Task SendFeedbackToService()
 		{
 			if (_translationService != null)
 			{
@@ -278,6 +293,11 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			{
 				_translationService.TranslationReceived += _translationService_TranslationReceived;
 			}
+		}
+
+		public void SetSendFeedback(bool sendFeedback)
+		{
+			SendFeedback = sendFeedback;
 		}
 	}
 }


### PR DESCRIPTION
… instead of when Editor controller is open.

Enable/Disable the rationg options based on Send feedback option from settings.