### PR TITLE
Update the plugin version to correspond to versioning standards.

### DIFF
--- a/Studio Migration Utility/Sdl.Community.PluginInfo/Sdl.Community.PluginInfo.csproj
+++ b/Studio Migration Utility/Sdl.Community.PluginInfo/Sdl.Community.PluginInfo.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -11,12 +11,13 @@
     <AssemblyName>Sdl.Community.PluginInfo</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-  <PluginDeploymentPath>$(AppData)\Sdl\Sdl Trados Studio\15\Plugins</PluginDeploymentPath></PropertyGroup>
+    <PluginDeploymentPath>$(AppData)\Sdl\Sdl Trados Studio\15\Plugins</PluginDeploymentPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>$(APPDATA)\SDL\SDL Trados Studio\15\Plugins\Packages\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>$(APPDATA)\SDL\SDL Trados Studio\15\Plugins\Packages\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Studio Migration Utility/Sdl.Community.StudioMigrationUtility/pluginpackage.manifest.xml
+++ b/Studio Migration Utility/Sdl.Community.StudioMigrationUtility/pluginpackage.manifest.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>Studio Migration Utility</PlugInName>
-	<Version>2.3.1</Version>
+	<Version>2.4.0.0</Version>
 	<Description>Studio Migration Utility</Description>
 	<Author>SDL Community Developers</Author>
-	<RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+	<RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0" />
 	<Include>
 		<File>Sdl.Community.Controls.dll</File>
 		<File>ObjectListView.dll</File>


### PR DESCRIPTION
Update plugin version to correspond to versioning standards (use 4 digits)
Set maxversion = "16.0" to not allow users to install the plugin on Studio 2021.