### PR TITLE
MXLIFF fix problem when file was not found at project creation

### DIFF
--- a/FileTypeSupport.MXLIFF/MXLIFFParser.cs
+++ b/FileTypeSupport.MXLIFF/MXLIFFParser.cs
@@ -15,45 +15,33 @@
 
     internal class MXLIFFParser : AbstractBilingualFileTypeComponent, IBilingualParser, INativeContentCycleAware, ISettingsAware
     {
-        private readonly Queue<int> tagIds = new Queue<int>();
-        private readonly Dictionary<int, IPlaceholderTagProperties> tags = new Dictionary<int, IPlaceholderTagProperties>();
-        private readonly Dictionary<string, string> users = new Dictionary<string, string>();
-        private XmlDocument document;
-        private IDocumentProperties documentProperties;
-        private IFileProperties fileProperties;
-        private XmlNamespaceManager nsmgr;
-        private int totalTagCount;
-        private int workflowLevel = 0;
+        private readonly Queue<int> _tagIds = new Queue<int>();
+        private readonly Dictionary<int, IPlaceholderTagProperties> _tags = new Dictionary<int, IPlaceholderTagProperties>();
+        private readonly Dictionary<string, string> _users = new Dictionary<string, string>();
+        private XmlDocument _document;
+        private IFileProperties _fileProperties;
+        private XmlNamespaceManager _nsmgr;
+        private int _totalTagCount;
+        private int _workflowLevel;
 
         public event EventHandler<ProgressEventArgs> Progress;
 
-        public IDocumentProperties DocumentProperties
-        {
-            get
-            {
-                return documentProperties;
-            }
-            set
-            {
-                documentProperties = value;
-            }
-        }
+        public IDocumentProperties DocumentProperties { get; set; }
 
         public IBilingualContentHandler Output
         {
-            get;
-            set;
+            get; set;
         }
 
         public void Dispose()
         {
-            document = null;
+            _document = null;
         }
 
         public void EndOfInput()
         {
             OnProgress(100);
-            document = null;
+            _document = null;
         }
 
         public void InitializeSettings(ISettingsBundle settingsBundle, string configurationId)
@@ -63,23 +51,23 @@
 
         public bool ParseNext()
         {
-            if (documentProperties == null)
+            if (DocumentProperties == null)
             {
-                documentProperties = ItemFactory.CreateDocumentProperties();
+                DocumentProperties = ItemFactory.CreateDocumentProperties();
             }
 
-            Output.Initialize(documentProperties);
+            Output.Initialize(DocumentProperties);
 
-            IFileProperties fileInfo = ItemFactory.CreateFileProperties();
-            fileInfo.FileConversionProperties = fileProperties.FileConversionProperties;
+            var fileInfo = ItemFactory.CreateFileProperties();
+            fileInfo.FileConversionProperties = _fileProperties.FileConversionProperties;
             Output.SetFileProperties(fileInfo);
 
             // Variables for the progress report
-            var xmlNodeList = document.SelectNodes("//x:group", nsmgr);
+            var xmlNodeList = _document.SelectNodes("//x:group", _nsmgr);
             if (xmlNodeList != null)
             {
-                int totalUnitCount = xmlNodeList.Count;
-                int currentUnitCount = 0;
+                var totalUnitCount = xmlNodeList.Count;
+                var currentUnitCount = 0;
                 foreach (XmlNode item in xmlNodeList)
                 {
                     foreach(var unit in CreateParagraphUnit(item))
@@ -101,28 +89,28 @@
 
         public void SetFileProperties(IFileProperties properties)
         {
-            fileProperties = properties;
+            _fileProperties = properties;
         }
 
         public void StartOfInput()
         {
             OnProgress(0);
-            document = new XmlDocument();
-            document.Load(fileProperties.FileConversionProperties.OriginalFilePath);
-            nsmgr = new XmlNamespaceManager(document.NameTable);
-            nsmgr.AddNamespace("x", "urn:oasis:names:tc:xliff:document:1.2");
-            nsmgr.AddNamespace("m", "http://www.memsource.com/mxlf/2.0");
+            _document = new XmlDocument();
+            _document.Load(_fileProperties.FileConversionProperties.OriginalFilePath);
+            _nsmgr = new XmlNamespaceManager(_document.NameTable);
+            _nsmgr.AddNamespace("x", "urn:oasis:names:tc:xliff:document:1.2");
+            _nsmgr.AddNamespace("m", "http://www.memsource.com/mxlf/2.0");
 
             // Acquire workflow level
-            var level = document.DocumentElement.Attributes["m:level"];
+            var level = _document.DocumentElement.Attributes["m:level"];
 
             if (level != null)
             {
-                workflowLevel = Int32.Parse(level.Value);
+                _workflowLevel = int.TryParse(level.Value, out _) ? int.Parse(level.Value) : 0;
             }
 
             // Acquire users
-            var memsourceUsers = document.SelectNodes("//m:user", nsmgr);
+            var memsourceUsers = _document.SelectNodes("//m:user", _nsmgr);
 
             if (memsourceUsers != null)
             {
@@ -131,7 +119,7 @@
                     var id = user.Attributes["id"]?.Value;
                     var username = user.Attributes["username"]?.Value;
 
-                    users.Add(id ?? "_UNKNOWN_", username ?? "_UNKNOWN_");
+                    _users.Add(id ?? "_UNKNOWN_", username ?? "_UNKNOWN_");
                 }
             }
         }
@@ -143,26 +131,25 @@
 
         private ICommentProperties CreateComment(XmlNode commentNode)
         {
-            ICommentProperties commentProperties = PropertiesFactory.CreateCommentProperties();
+	        var commentProperties = PropertiesFactory.CreateCommentProperties();
 
-            var createdBy = commentNode.Attributes["created-by"]?.Value;
-            var resolved = commentNode.Attributes["resolved"]?.Value;
+            var createdBy = commentNode?.Attributes?["created-by"]?.Value;
+            var resolved = commentNode?.Attributes?["resolved"]?.Value;
 
-            string author = string.Empty;
+            var author = string.Empty;
             if (createdBy != null)
             {
-                author = users[createdBy];
+                author = _users[createdBy];
             }
 
-            Severity severity = Severity.Low;
+            var severity = Severity.Low;
 
             if (resolved != null && (resolved == "false"))
             {
                 severity = Severity.Medium;
             }
 
-            var comment = PropertiesFactory.CreateComment(commentNode.InnerText,
-                                                          author, severity);
+            var comment = PropertiesFactory.CreateComment(commentNode.InnerText, author, severity);
 
             commentProperties.Add(comment);
 
@@ -175,12 +162,12 @@
 
             if (transUnit != null)
             {
-                var confirmed = transUnit.Attributes["m:confirmed"];
-                var levelEdited = transUnit.Attributes["m:level-edited"];
+                var confirmed = transUnit.Attributes?["m:confirmed"];
+                var levelEdited = transUnit.Attributes?["m:level-edited"];
 
                 if (confirmed != null && (confirmed.Value == "1"))
                 {
-                    if (workflowLevel > 1 && levelEdited != null && (levelEdited.Value == "true"))
+                    if (_workflowLevel > 1 && levelEdited != null && (levelEdited.Value == "true"))
                     {
                         sdlxliffLevel = ConfirmationLevel.ApprovedTranslation;
                     }
@@ -191,13 +178,13 @@
                 }
                 else
                 {
-                    if (workflowLevel > 1 && levelEdited != null && (levelEdited.Value == "true"))
+                    if (_workflowLevel > 1 && levelEdited != null && (levelEdited.Value == "true"))
                     {
                         sdlxliffLevel = ConfirmationLevel.RejectedTranslation;
                     }
                     else
                     {
-                        var target = transUnit.SelectSingleNode("x:target", nsmgr);
+                        var target = transUnit.SelectSingleNode("x:target", _nsmgr);
                         if (target != null && !string.IsNullOrWhiteSpace(target.InnerText))
                         {
                             sdlxliffLevel = ConfirmationLevel.Draft;
@@ -219,14 +206,14 @@
 
         private IContextProperties CreateContext(string id, string paraId)
         {
-            IContextProperties contextProperties = PropertiesFactory.CreateContextProperties();
+	        var contextProperties = PropertiesFactory.CreateContextProperties();
 
-            IContextInfo contextId = PropertiesFactory.CreateContextInfo("id");
+            var contextId = PropertiesFactory.CreateContextInfo("id");
             contextId.SetMetaData("ID", id);
             contextId.Description = "Trans-unit id";
             contextId.DisplayCode = "ID";
 
-            IContextInfo contextParaId = PropertiesFactory.CreateContextInfo("para-id");
+            var contextParaId = PropertiesFactory.CreateContextInfo("para-id");
             contextParaId.SetMetaData("PARA ID", paraId);
             contextParaId.Description = "Para-id";
             contextParaId.DisplayCode = "PARA ID";
@@ -237,17 +224,17 @@
             return contextProperties;
         }
 
-        private Byte CreateMatchValue(XmlNode transUnit)
+        private byte CreateMatchValue(XmlNode transUnit)
         {
-            Byte matchValue = 0;
+            byte matchValue = 0;
 
             // "m:gross-score" and "m:score" are both percentage values of TM matches from which the given segment is pre-translated.
             // "m:gross-score" is the percentage prior to the application of TM penalization, if any, while "m:score" is the percentage after penalization.
-            var score = transUnit.Attributes["m:score"];
+            var score = transUnit?.Attributes?["m:score"];
 
             if (score != null)
             {
-                matchValue = Convert.ToByte(Convert.ToDouble(score.Value, CultureInfo.InvariantCulture.NumberFormat) * 100);
+	            matchValue = Convert.ToByte(Convert.ToDouble(score.Value, CultureInfo.InvariantCulture.NumberFormat) * 100);
             }
 
             return matchValue;
@@ -255,14 +242,13 @@
 
         private List<IParagraphUnit> CreateParagraphUnit(XmlNode xmlUnit)
         {
-            List<IParagraphUnit> units = new List<IParagraphUnit>();
-
-            var xmlNodes = xmlUnit.SelectNodes("x:trans-unit", nsmgr);
+	        var units = new List<IParagraphUnit>();
+	        var xmlNodes = xmlUnit.SelectNodes("x:trans-unit", _nsmgr);
 
             foreach (XmlNode xmlNode in xmlNodes)
             {
-                // Create paragraph unit object
-                IParagraphUnit paragraphUnit = ItemFactory.CreateParagraphUnit(LockTypeFlags.Unlocked);
+				// Create paragraph unit object
+				var paragraphUnit = ItemFactory.CreateParagraphUnit(LockTypeFlags.Unlocked);
 
                 if (xmlNode != null)
                 {
@@ -274,23 +260,23 @@
                         paragraphUnit.Properties.Contexts = CreateContext(id.Value, paraId.Value);
                     }
 
-                    // Create segment pair object
-                    ISegmentPairProperties segmentPairProperties = ItemFactory.CreateSegmentPairProperties();
-                    ITranslationOrigin tuOrg = ItemFactory.CreateTranslationOrigin();
+					// Create segment pair object
+					var segmentPairProperties = ItemFactory.CreateSegmentPairProperties();
+                    var tuOrg = ItemFactory.CreateTranslationOrigin();
 
                     // Assign the appropriate confirmation level to the segment pair
                     segmentPairProperties.ConfirmationLevel = CreateConfirmationLevel(xmlNode);
                     tuOrg.MatchPercent = CreateMatchValue(xmlNode);
 
                     // Add source segment to paragraph unit
-                    ISegment srcSegment = CreateSegment(xmlNode.SelectSingleNode("x:source", nsmgr), segmentPairProperties, true);
+                    var srcSegment = CreateSegment(xmlNode.SelectSingleNode("x:source", _nsmgr), segmentPairProperties, true);
 
                     paragraphUnit.Source.Add(srcSegment);
 
                     // Add target segment to paragraph unit if available
-                    if (xmlNode.SelectSingleNode("x:target", nsmgr) != null)
+                    if (xmlNode.SelectSingleNode("x:target", _nsmgr) != null)
                     {
-                        ISegment trgSegment = CreateSegment(xmlNode.SelectSingleNode("x:target", nsmgr), segmentPairProperties, false);
+                        var trgSegment = CreateSegment(xmlNode.SelectSingleNode("x:target", _nsmgr), segmentPairProperties, false);
 
                         // Check if locked
                         var locked = xmlNode.Attributes["m:locked"];
@@ -302,12 +288,12 @@
                         // Check if target empty and look for alt-trans
                         if (trgSegment.Count == 0)
                         {
-                            var alttrans = xmlNode.SelectSingleNode("x:alt-trans/x:target", nsmgr);
+                            var alttrans = xmlNode.SelectSingleNode("x:alt-trans/x:target", _nsmgr);
                             if (alttrans != null && !string.IsNullOrWhiteSpace(alttrans.InnerText))
                             {
                                 PopulateSegment(trgSegment, alttrans, false);
 
-                                var alttransOrigin = xmlNode.SelectSingleNode("x:alt-trans", nsmgr).Attributes["origin"];
+                                var alttransOrigin = xmlNode.SelectSingleNode("x:alt-trans", _nsmgr).Attributes["origin"];
                                 if (alttransOrigin != null)
                                 {
                                     var origin = alttransOrigin.Value;
@@ -329,9 +315,9 @@
                     }
                     else
                     {
-                        var singleNode = xmlNode.SelectSingleNode("x:source", nsmgr);
+                        var singleNode = xmlNode.SelectSingleNode("x:source", _nsmgr);
                         if (singleNode != null) singleNode.InnerText = "";
-                        ISegment trgSegment = CreateSegment(xmlNode.SelectSingleNode("x:source", nsmgr), segmentPairProperties, false);
+                        var trgSegment = CreateSegment(xmlNode.SelectSingleNode("x:source", _nsmgr), segmentPairProperties, false);
                         paragraphUnit.Target.Add(trgSegment);
                     }
 
@@ -344,14 +330,14 @@
                     segmentPairProperties.TranslationOrigin = tuOrg;
 
                     // Add comments
-                    if (xmlNode.SelectSingleNode("m:comment", nsmgr) != null)
+                    if (xmlNode.SelectSingleNode("m:comment", _nsmgr) != null)
                     {
-                        paragraphUnit.Properties.Comments = CreateComment(xmlNode.SelectSingleNode("m:comment", nsmgr));
+                        paragraphUnit.Properties.Comments = CreateComment(xmlNode.SelectSingleNode("m:comment", _nsmgr));
                     }
                 }
 
                 // Clear any ids on the queue
-                tagIds.Clear();
+                _tagIds.Clear();
 
                 units.Add(paragraphUnit);
             }
@@ -361,43 +347,43 @@
 
         private IPlaceholderTag CreatePhTag(string tagContent, int tagNo, bool source)
         {
-            IPlaceholderTagProperties phTagProperties = PropertiesFactory.CreatePlaceholderTagProperties(tagContent);
-            IPlaceholderTag phTag = ItemFactory.CreatePlaceholderTag(phTagProperties);
+	        var phTagProperties = PropertiesFactory.CreatePlaceholderTagProperties(tagContent);
+	        var phTag = ItemFactory.CreatePlaceholderTag(phTagProperties);
 
             phTagProperties.TagContent = tagContent;
-            phTagProperties.DisplayText = string.Format("{{{0}}}", tagNo);
+            phTagProperties.DisplayText = $@"{{{tagNo}}}";
             phTagProperties.CanHide = false;
 
             if (source)
             {
-                var thisId = new TagId(totalTagCount.ToString(CultureInfo.InvariantCulture));
+                var thisId = new TagId(_totalTagCount.ToString(CultureInfo.InvariantCulture));
 
                 phTagProperties.TagId = thisId;
 
-                if (tags.ContainsKey(int.Parse(thisId.Id)) && !tags.ContainsValue(phTagProperties))
+                if (_tags.ContainsKey(int.Parse(thisId.Id)) && !_tags.ContainsValue(phTagProperties))
                 {
-                    totalTagCount = CreatePlaceholderTagHelper(thisId, phTagProperties);
+                    _totalTagCount = CreatePlaceholderTagHelper(thisId, phTagProperties);
                 }
 
-                if (!(tags.ContainsKey(int.Parse(thisId.Id)) && tags.ContainsValue(phTagProperties)))
+                if (!(_tags.ContainsKey(int.Parse(thisId.Id)) && _tags.ContainsValue(phTagProperties)))
                 {
-                    tags.Add(totalTagCount, phTagProperties);
+                    _tags.Add(_totalTagCount, phTagProperties);
                 }
 
-                tagIds.Enqueue(totalTagCount);
+                _tagIds.Enqueue(_totalTagCount);
 
-                totalTagCount++;
+                _totalTagCount++;
             }
             else
             {
                 int id;
-                if (tagIds.Count != 0)
+                if (_tagIds.Count != 0)
                 {
-                    id = tagIds.Dequeue();
+                    id = _tagIds.Dequeue();
                 }
                 else
                 {
-                    id = totalTagCount++;
+                    id = _totalTagCount++;
                 }
 
 
@@ -405,9 +391,9 @@
 
                 phTagProperties.TagId = thisId;
 
-                if (tags.ContainsKey(int.Parse(thisId.Id)) && !tags.ContainsValue(phTagProperties))
+                if (_tags.ContainsKey(int.Parse(thisId.Id)) && !_tags.ContainsValue(phTagProperties))
                 {
-                    totalTagCount = CreatePlaceholderTagHelper(thisId, phTagProperties);
+                    _totalTagCount = CreatePlaceholderTagHelper(thisId, phTagProperties);
                 }
             }
 
@@ -416,19 +402,19 @@
 
         private int CreatePlaceholderTagHelper(TagId placeholderId, IPlaceholderTagProperties phTagProperties)
         {
-            var max = tags.Keys.Max();
+            var max = _tags.Keys.Max();
             var id = max + 1;
             placeholderId.Id = id.ToString();
             phTagProperties.TagId = placeholderId;
 
-            tags.Add(id, phTagProperties);
+            _tags.Add(id, phTagProperties);
 
             return id;
         }
 
         private ISegment CreateSegment(XmlNode segNode, ISegmentPairProperties pair, bool source)
         {
-            ISegment segment = ItemFactory.CreateSegment(pair);
+            var segment = ItemFactory.CreateSegment(pair);
 
             PopulateSegment(segment, segNode, source);
 
@@ -437,8 +423,8 @@
 
         private IText CreateText(string segText)
         {
-            ITextProperties textProperties = PropertiesFactory.CreateTextProperties(segText);
-            IText textContent = ItemFactory.CreateText(textProperties);
+            var textProperties = PropertiesFactory.CreateTextProperties(segText);
+            var textContent = ItemFactory.CreateText(textProperties);
 
             return textContent;
         }

--- a/FileTypeSupport.MXLIFF/MXLIFFWriter.cs
+++ b/FileTypeSupport.MXLIFF/MXLIFFWriter.cs
@@ -5,10 +5,12 @@ using Sdl.FileTypeSupport.Framework.NativeApi;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using Sdl.Community.FileTypeSupport.MXLIFF.Utils;
 
 namespace Sdl.Community.FileTypeSupport.MXLIFF
 {
@@ -20,6 +22,12 @@ namespace Sdl.Community.FileTypeSupport.MXLIFF
 		private XmlDocument _targetFile;
 		private MXLIFFTextExtractor _textExtractor;
 		private readonly Dictionary<string, string> _users = new Dictionary<string, string>();
+		private readonly Helper _helper;
+	
+		public MXLIFFWriter()
+		{
+			_helper = new Helper();
+		}
 
 		public void Complete()
 		{
@@ -60,9 +68,13 @@ namespace Sdl.Community.FileTypeSupport.MXLIFF
 
 		public void SetFileProperties(IFileProperties fileInfo)
 		{
-			_targetFile = new XmlDocument();
-			_targetFile.PreserveWhitespace = false;
-			_targetFile.Load(_originalFileProperties.OriginalFilePath);
+			_targetFile = new XmlDocument
+			{
+				PreserveWhitespace = false
+			};
+
+			LoadFile();
+
 			_nsmgr = new XmlNamespaceManager(_targetFile.NameTable);
 			_nsmgr.AddNamespace("x", "urn:oasis:names:tc:xliff:document:1.2");
 			_nsmgr.AddNamespace("m", "http://www.memsource.com/mxlf/2.0");
@@ -86,6 +98,23 @@ namespace Sdl.Community.FileTypeSupport.MXLIFF
 		public void SetOutputProperties(INativeOutputFileProperties properties)
 		{
 			_nativeFileProperties = properties;
+		}
+
+		private void LoadFile()
+		{
+			if (_originalFileProperties != null)
+			{
+				var backupFile = _helper.GetBackupFile(Path.GetFileNameWithoutExtension(_originalFileProperties.OriginalFilePath));
+				if (File.Exists(_originalFileProperties.OriginalFilePath))
+				{
+					_targetFile.Load(_originalFileProperties.OriginalFilePath);
+				}
+
+				else if (!string.IsNullOrWhiteSpace(backupFile) && File.Exists(backupFile))
+				{
+					_targetFile.Load(backupFile);
+				}
+			}
 		}
 
 		private static void UpdateConfirmedAttribute(XmlNode transUnit, ISegmentPair segmentPair)
@@ -350,7 +379,6 @@ namespace Sdl.Community.FileTypeSupport.MXLIFF
 
 			node.InnerText = _textExtractor.GetPlainText(seg);
 		}
-
 
 		private void UpdateSegment(XmlNode transUnit, ISegmentPair segmentPair)
 		{

--- a/FileTypeSupport.MXLIFF/Sdl.Community.FileTypeSupport.MXLIFF.csproj
+++ b/FileTypeSupport.MXLIFF/Sdl.Community.FileTypeSupport.MXLIFF.csproj
@@ -135,6 +135,7 @@
     <Compile Include="TellMe\MXLIFFCommunityWikiAction.cs" />
     <Compile Include="TellMe\MXLIFFStoreAction.cs" />
     <Compile Include="TellMe\MXLIFFTellMeProvider.cs" />
+    <Compile Include="Utils\Helper.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="PluginResources.resx">
@@ -183,5 +184,6 @@
       <Version>16.0.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FileTypeSupport.MXLIFF/Utils/Helper.cs
+++ b/FileTypeSupport.MXLIFF/Utils/Helper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+
+namespace Sdl.Community.FileTypeSupport.MXLIFF.Utils
+{
+	public class Helper
+	{
+		private readonly string _communityFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SDL Community", "MXLIFF File Type Support", "Native MXLIFF Files");
+
+		// Backup the native .mxliff file locally
+		// When user creates a project using the new project wizard, the native file is used when user saves the translated file using "Save Target As" option
+		public void BackupNativeFile(string nativeFilePath)
+		{
+			Directory.CreateDirectory(_communityFolder);
+
+			var backupFile = Path.Combine(_communityFolder, Path.GetFileName(nativeFilePath));
+			File.Copy(nativeFilePath, backupFile, true);
+		}
+
+		// Get the corresponding mxliff file from the backup  native files folder
+		public string GetBackupFile(string fileNamePath)
+		{
+			var fileName = Path.GetFileNameWithoutExtension(fileNamePath);
+			var mxliffFiles = Directory.GetFiles(_communityFolder);
+
+			foreach (var file in mxliffFiles)
+			{
+				if (Path.GetFileNameWithoutExtension(file).Equals(fileName))
+				{
+					return file;
+				}
+			}
+
+			return string.Empty;
+		}
+	}
+}

--- a/FileTypeSupport.MXLIFF/pluginpackage.manifest.xml
+++ b/FileTypeSupport.MXLIFF/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>MXLIFF File Type</PlugInName>
-  <Version>3.6.2.0</Version>
+  <Version>3.6.3.0</Version>
   <Description>This plugin provides support for handling MXLIFF files created from memsource.</Description>
   <Author>SDL Community Developers</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0"/>


### PR DESCRIPTION
Apply the following changes performed on Studio 2019 solution (which were code reviewed):
-Fix file not found issue : backup the native mxliff file and use it when user creates a new project based on mxliff file and exports the translated file (which is used further in Memsource web).
-Apply code cleaning.
-Update plugin version.