### PR TITLE
Fix issue when translation to Portuguese(Portugual) or Portuguese(Brazilian)

### DIFF
--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
@@ -51,7 +51,7 @@ namespace Sdl.Community.DeepLMTProvider
 
 		public string Translate(LanguagePair languageDirection, string sourceText)
 		{
-			var targetLanguage = languageDirection.TargetCulture.TwoLetterISOLanguageName;
+			var targetLanguage = GetTargetLanguage(languageDirection);
 			var sourceLanguage = languageDirection.SourceCulture.TwoLetterISOLanguageName;
 			var translatedText = string.Empty;
 			var normalizeHelper = new NormalizeSourceTextHelper();
@@ -120,6 +120,15 @@ namespace Sdl.Community.DeepLMTProvider
 			translatedText = amp.Replace(translatedText, "&");
 
 			return translatedText;
+		}
+
+		// Get the target language based on language direction
+		// (for Portuguese, the leftLanguageTag (pt-PT or pt-BR) should be used, so the translations will correspond to the specific language flavor)
+		private string GetTargetLanguage(LanguagePair languageDirection)
+		{
+			return languageDirection.TargetCulture.DisplayName.Contains("Portuguese")
+				? languageDirection.TargetCulture.Name
+				: languageDirection.TargetCulture.TwoLetterISOLanguageName;
 		}
 	}
 }

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>DeepL Translation Provider</PlugInName>
-  <Version>4.8.13.0</Version>
+  <Version>4.8.14.0</Version>
   <Description>This plugin provides machine translation results from the DeepL Translator.</Description>
   <Author>SDL Community Developers</Author>
   <Include>
-		<File>Sdl.Community.DeepLMTProvider.WPF.dll</File>
-		<File>MahApps.Metro.dll</File>
-		<File>System.Windows.Interactivity.dll</File>
+	  <File>Sdl.Community.DeepLMTProvider.WPF.dll</File>
+	  <File>MahApps.Metro.dll</File>
+	  <File>System.Windows.Interactivity.dll</File>
 	</Include>
   <RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0"/>
 </PluginPackage>


### PR DESCRIPTION
Fix when translating files with target language Portuguese(Portugal) or Portuguese(Brazilian) flavor. The language sent to DeepL should be set specific of flavor(pt-PT or pt-BR), instead of pt.

Update plugin's version