### PR TITLE
Apply fix from 2019 version: don't use in number verification the separators which are punctuation marks: ex:  text,200

### DIFF
--- a/Number Verifier/Helpers/TextFormatter.cs
+++ b/Number Verifier/Helpers/TextFormatter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace Sdl.Community.NumberVerifier.Helpers
@@ -177,6 +178,42 @@ namespace Sdl.Community.NumberVerifier.Helpers
 			}
 
 			return numberText;
+		}
+
+		public char[] GetSeparatorsChars(string customDecimalSeparators, string customThousandSeparators)
+		{
+			var decimalSep = customDecimalSeparators.ToCharArray();
+			var thousandSep = customThousandSeparators.ToCharArray();
+			var separatorsChars = new[] { ',', '.' }.Concat(decimalSep).Concat(thousandSep).ToArray();
+
+			return separatorsChars;
+		}
+
+		// When number has the last or first char one of the separators, remove it because we don't need it.
+		// Is not corresponding to decimal/thousand separator, it's used as simple punctuation letter (Eg: ,123 or 245, )
+		public string RemovePunctuationChar(string text, char[] sepChars, bool omitLeadingZero)
+		{
+			if (text.Length - 1 == text.LastIndexOfAny(sepChars))
+			{
+				text = text.Remove(text.Length - 1, 1);
+			}
+
+			if (text.IndexOfAny(sepChars) == 0 && !omitLeadingZero)
+			{
+				text = text.Remove(0, 1);
+			}
+
+			if (!string.IsNullOrWhiteSpace(text) && IsPunctuationChar(text, sepChars))
+			{
+				text = RemovePunctuationChar(text, sepChars, omitLeadingZero);
+			}
+			
+			return text.Trim();
+		}
+
+		private bool IsPunctuationChar(string text, char[] sepChars)
+		{
+			return text.IndexOfAny(sepChars) == 0 || text.Length - 1 == text.LastIndexOfAny(sepChars);
 		}
 	}
 }

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/Alphanumeric/AlphanumericCustomSeparators.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/Alphanumeric/AlphanumericCustomSeparators.cs
@@ -7,6 +7,13 @@ namespace Sdl.Community.NumberVerifier.Tests.Alphanumeric
 {
 	public class AlphanumericCustomSeparators
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public AlphanumericCustomSeparators()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		[Theory]
 		[InlineData("BS2-3", "-")]
 		public void FindAlphanumericWithCustomSeparators(string text, string customSeparators)
@@ -19,8 +26,7 @@ namespace Sdl.Community.NumberVerifier.Tests.Alphanumeric
 
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var textAlphanumericsList = numberVerifierMain.GetAlphanumericList(text);
 
@@ -39,8 +45,7 @@ namespace Sdl.Community.NumberVerifier.Tests.Alphanumeric
 
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var textAlphanumericsList = numberVerifierMain.GetAlphanumericList(text);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/Alphanumeric/NormalizeAlphanumerics.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/Alphanumeric/NormalizeAlphanumerics.cs
@@ -8,12 +8,18 @@ using Xunit;
 namespace Sdl.Community.NumberVerifier.Tests.Alphanumeric
 {
 	public class NormalizeAlphanumerics
-    {        
-        public List<ErrorReporting> ReportModifiedAlphanumerics(string source, string target,NumberVerifierMain numberVerifierMain)
+    {
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public NormalizeAlphanumerics()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
+		public List<ErrorReporting> ReportModifiedAlphanumerics(string source, string target,NumberVerifierMain numberVerifierMain)
         {     
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             return numberVerifierMain.CheckSourceAndTarget(source, target);
         }

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/CheckFullWidthJapaneseNumbers.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/CheckFullWidthJapaneseNumbers.cs
@@ -8,11 +8,16 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class CheckFullWidthJapaneseNumbers
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public CheckFullWidthJapaneseNumbers()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		/// <summary>
 		/// Validate the full-width Japanese numbers: ２０１６ -> 2016
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
 		[InlineData("２０１６", "2016")]
 		public void ValidateFullWidthJapaneseNumbers(string source, string target)
@@ -24,8 +29,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/CheckNumbersAgainstRegularExpression.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/CheckNumbersAgainstRegularExpression.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Moq;
+﻿using Moq;
 using Sdl.Community.NumberVerifier.Tests.Utilities;
 using Sdl.FileTypeSupport.Framework.BilingualApi;
 using Xunit;
@@ -8,14 +7,18 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class CheckNumbersAgainstRegularExpression
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public CheckNumbersAgainstRegularExpression()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		/// <summary>
-        /// In case of -(space)number the dash should be ignored because is not a negative number  
-        /// is a item in a list
-        /// </summary>
-        /// <param name="text"></param>
-        /// <param name="thousandSep"></param>
-        /// <param name="decimalSep"></param>
-        [Theory]
+		/// In case of -(space)number the dash should be ignored because is not a negative number  
+		/// is a item in a list
+		/// </summary>
+		[Theory]
         [InlineData("- 34", ".,", ",")]
         public void SkipTheDash(string text, string thousandSep, string decimalSep)
         {
@@ -26,8 +29,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var thousandSeparators = numberVerifierMain.AddCustomSeparators(thousandSep,true);
             var decimalSeparators = numberVerifierMain.AddCustomSeparators(decimalSep,true);
@@ -37,7 +39,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 
             Assert.Equal("34", normalizeNumber.InitialNumberList[0]);
             Assert.Equal("34", normalizeNumber.NormalizedNumberList[0]);
-            
         }
 
         [Theory]
@@ -50,8 +51,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 			
             var thousandSeparators = numberVerifierMain.AddCustomSeparators(thousandSep,true);
             var decimalSeparators = numberVerifierMain.AddCustomSeparators(decimalSep,true);
@@ -74,8 +74,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var thousandSeparators = numberVerifierMain.AddCustomSeparators(thousandSep,true);
             var decimalSeparators = numberVerifierMain.AddCustomSeparators(decimalSep,true);
@@ -99,8 +98,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			// run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var thousandSeparators = numberVerifierMain.AddCustomSeparators(thousandSep, true);
 			var decimalSeparators = numberVerifierMain.AddCustomSeparators(decimalSep, true);
@@ -126,8 +124,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var thousandSeparators = numberVerifierMain.AddCustomSeparators(thousandSep, true);
 			var decimalSeparators = numberVerifierMain.AddCustomSeparators(decimalSep, true);

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/HindiNumbers.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/HindiNumbers.cs
@@ -8,12 +8,16 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class HindiNumbers
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public HindiNumbers()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		/// <summary>
 		/// Validate correct numbers from Hindi to Arabic
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <param name="sourceLanguage"></param>
 		[Theory]
 		[InlineData("١.٢٣٤,٨٩", "1.234,89", "Hindi (India)")]
 		public void CheckFromHindiToArabicValid(string source, string target, string sourceLanguage)
@@ -26,8 +30,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var results = numberVerifierMain.GetTargetFromHindiNumbers(source, target, sourceLanguage);
 
@@ -37,9 +40,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// <summary>
 		/// Validate wrong numbers from Hindi to Arabic  
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <param name="sourceLanguage"></param>
 		[Theory]
 		[InlineData("١٢٣.٤,٨٩", "12.34,89", "Hindi (India)")]
 		public void CheckFromHindiToArabicInvalid(string source, string target, string sourceLanguage)
@@ -52,8 +52,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var results = numberVerifierMain.GetTargetFromHindiNumbers(source, target, sourceLanguage);
 			if (results.Any())
@@ -65,9 +64,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// <summary>
 		/// Validate correct numbers from Arabic to Hindi
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <param name="sourceLanguage"></param>
 		[Theory]
 		[InlineData("1.234,89", "١.٢٣٤,٨٩", "Arabic (Arabic)")]
 		public void CheckFromArabicToHindiValid(string source, string target, string sourceLanguage)
@@ -80,8 +76,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var results = numberVerifierMain.GetTargetFromHindiNumbers(source, target, sourceLanguage);
 
@@ -91,9 +86,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// <summary>
 		/// Validate wrong numbers from Arabic to Hindi
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
-		/// <param name="sourceLanguage"></param>
 		[Theory]
 		[InlineData("12.34,89", "١٢٣.٤,٨٩", "Arabic (Arabic)")]
 		public void CheckFromArabicToHindiInValid(string source, string target, string sourceLanguage)
@@ -106,8 +98,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var results = numberVerifierMain.GetTargetFromHindiNumbers(source, target, sourceLanguage);
 			if (results.Any())

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/MultipleErrors.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/MultipleErrors.cs
@@ -7,6 +7,13 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class MultipleErrors
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public MultipleErrors()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		[Theory]
 		[InlineData("1,554,5 alphanumeric AB23", " wrong separator 1 554.5 wrong alphanumeric BC12")]
 		public void ThousandsNumbersAndAlphanumerics(string source, string target)
@@ -23,8 +30,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/NormalizeNumbersAllowLocalization.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/NormalizeNumbersAllowLocalization.cs
@@ -1,5 +1,4 @@
 ﻿using Moq;
-using Sdl.Community.NumberVerifier.Model;
 using Sdl.Community.NumberVerifier.Tests.Utilities;
 using Sdl.FileTypeSupport.Framework.BilingualApi;
 using Xunit;
@@ -8,6 +7,13 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class NormalizeNumbersAllowLocalization
 	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public NormalizeNumbersAllowLocalization()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
 		[Theory]
 		[InlineData("1,55", "1.55")]
 		public void NormalizeDecimalNumbersComma(string source, string target)
@@ -25,8 +31,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/NormalizeNumbersNoSeparator.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/NormalizeNumbersNoSeparator.cs
@@ -8,7 +8,14 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 {
 	public class NormalizeNumbersNoSeparator
     {
-	    [Theory]
+	    private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public NormalizeNumbersNoSeparator()
+	    {
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
+		[Theory]
         [InlineData("1,55", " ", ",", true)]
         public string NormalizeNoSeparatorNumbers(string text, string thousandSep, string decimalSep, bool noSeparator)
         {
@@ -19,8 +26,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 			
             var normalizedNumber = numberVerifierMain.NormalizeNumber(new SeparatorModel
 			{
@@ -51,8 +57,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -74,8 +79,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -99,8 +103,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationAllow.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationAllow.cs
@@ -10,6 +10,12 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	/// </summary>
 	public class SourceAndTargetNormalizationAllow
     {
+	    private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public SourceAndTargetNormalizationAllow()
+	    {
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
 
         #region Check thousands numbers and negative numbers
 
@@ -18,8 +24,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Decimal sep: period
         /// Error: no error
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1.554,5 negative number -1.554,5", "1,554,5 negative -1.554,5")]
         public void ThousandsSeparatorsCommaPeriod(string source, string target)
@@ -30,8 +34,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -42,8 +45,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Thousands sep: comma, period, space
         /// Decimal: comma
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1 554,5 some word 1.234,5 another word -1 222,3", "1.554,5 test 1,234,5 another test word −1.222,3")]
         public void ThousandsSeparatorsSpaceCommaPeriod(string source, string target)
@@ -54,8 +55,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -72,8 +72,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -83,8 +82,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Thousands sep: space, thin space, no-break space
         /// Decimal sep: comma, period
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1 554.5 some word 1 234,5 another word −1 222,3", "1 554,5 test 1 234.5 another test word -1 222,3")]
         public void ThousandsSeparatorsAllTypesOfSpaces(string source, string target)
@@ -96,8 +93,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -108,8 +104,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Thousands sep: no separator, comma, period
         /// Decimal sep: comma, period
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,554.5 some word 1.234,5 another word 1.222,3", "1,554,5 test 1,234.5 another test word 1.222,3")]
         public void ThousandsSeparatorsNoSeparatorCommaPeriod(string source, string target)
@@ -127,8 +121,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -142,8 +135,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// <summary>
         /// Check decimal numbers, both numbers should have comma as separator
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,55", "1.55")]
         public void DecimalSeparatorsComma(string source, string target)
@@ -156,8 +147,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -167,9 +157,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// <summary>
 		/// Check decimal numbers, numbers can have period or comma as separator
 		/// Error message: Number modified
-		/// /// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
+		/// </summary>
 		[Theory]
 		[InlineData("1,55", "1.55")]
 		public void DecimalSeparatorsComma_WithErrors(string source, string target)
@@ -182,8 +170,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -194,8 +181,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Check decimal numbers, numbers can have period or comma as separator
 		/// No error message
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
         [InlineData("2,55", "2.55")]
         public void DecimalSeparatorsCommaAndPeriod(string source, string target)
@@ -208,8 +193,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -224,8 +208,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Check decimal numbers and removed numbers error.
         /// Error: Number removed.
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("2,55 1,25", "2.55")]
         public void CheckForRemovedNumbers(string source, string target)
@@ -238,8 +220,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -250,8 +231,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Check decimal numbers and added numbers error.
         /// Error: Number added.
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("2,55", "2.55 1,25")]
         public void CheckForAddedNumbers(string source, string target)
@@ -264,8 +243,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
             Assert.Equal(PluginResources.Error_NumbersAdded, errorMessage[0].ErrorMessage);

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationPrevent.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationPrevent.cs
@@ -11,12 +11,16 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	/// </summary>
 	public class SourceAndTargetNormalizationPrevent
     {
-        
+	    private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public SourceAndTargetNormalizationPrevent()
+	    {
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
         /// <summary>
         /// Decimal separators : comma, period
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,55", "1.55")]
         public void DecimalSeparatorsComma(string source, string target)
@@ -33,8 +37,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationRequire.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/NormalizeNumbers/SourceAndTargetNormalizationRequire.cs
@@ -9,14 +9,19 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	/// Target separators
 	/// </summary>
 	public class SourceAndTargetNormalizationRequire
-    {
+	{
+		private readonly Mock<IDocumentProperties> _documentProperties;
+
+		public SourceAndTargetNormalizationRequire()
+		{
+			_documentProperties = new Mock<IDocumentProperties>();
+		}
+
         #region Check thousands numbers
         /// <summary>
         /// Source sep: decimal - comma , thousands - comma
         /// Target sep: decimal - period, thousands - comma, period, space
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,554,5 negative number -1,554,5", "1,554.5 negative -1 554.5")]
         public void ThousandsSeparatorsSpaceCommaPeriod(string source, string target)
@@ -31,8 +36,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -43,8 +47,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Source sep: 'No separator' checked
         /// Target sep: thousands - comma, 'No separator' checked
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1000", "1,000")]
         public void ValidateTarget_ThousandsSeparatorsComma_NoSeparatorIsChecked(string source, string target)
@@ -60,8 +62,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -73,8 +74,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Target sep: 'No separator' checked
 		/// Verification error: Number(s) modified/unlocalised.
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
         [InlineData("1000", "2,000")]
         public void ValidateTarget_NoSeparatorIsChecked_Errors(string source, string target)
@@ -88,22 +87,18 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
 	        Assert.Equal(PluginResources.Error_NumbersNotIdentical, errorMessage[0].ErrorMessage);
         }
 
-
 		/// <summary>
 		/// Source sep: Thousand comma sep, 'No separator' checked
 		/// Target sep: 'No separator' checked
 		/// No validation error should be displayed
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
 		[InlineData("1,000", "1000")]
 		public void ValidateSource_ThousandsSeparatorsComma_NoSeparatorIsChecked(string source, string target)
@@ -120,8 +115,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -133,8 +127,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Target sep: 'No separator' checked
 		/// Verification error: no errors should be returned.
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
 		[InlineData("1,000", "1000")]
 		public void ValidateTarget_NoSeparatorIsChecked_NoErrors(string source, string target)
@@ -150,8 +142,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -163,8 +154,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Target sep: 'Comma' checked
 		/// Verification error: no errors should be returned.
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
 		[InlineData("1000", "1,000")]
 		public void ValidateSource_NoSeparatorIsChecked_NoErrors(string source, string target)
@@ -180,8 +169,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 			//run initialize method in order to set chosen separators
-			var docPropMock = new Mock<IDocumentProperties>();
-			numberVerifierMain.Initialize(docPropMock.Object);
+			numberVerifierMain.Initialize(_documentProperties.Object);
 
 			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -192,8 +180,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Source sep: decimal - comma , thousands - comma, period, space
 		/// Target sep: decimal - comma, thousands - comma, period
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
         [InlineData("1 554,5 some word 1.234,5 another word -1,222,3", "1.554,5 test 1,234,5 another test word −1.222,3")]
         public void ThousandsSeparatorsCommaPeriod(string source, string target)
@@ -210,21 +196,242 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
             Assert.True(errorMessage.Count == 0);
         }
 
-        /// <summary>
-        /// Check for negative numbers
-        /// Error : number modified/unlocalized
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
-        [Theory]
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("Simple test with comma after number 1000,for all", "1,000")]
+		public void ValidateSource_ThousandAfterComma_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: modified number error should be returned
+		/// </summary>
+		[Theory]
+		[InlineData("2000,", "1,000")]
+		public void ValidateSource_ThousandAfterComma_WithErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.Equal(errorMessage[0].ErrorMessage, PluginResources.Error_NumbersNotIdentical);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("Simple test with comma before number,1000", "1,000")]
+		public void ValidateSource_ThousandBeforeComma_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: modified number error should be returned
+		/// </summary>
+		[Theory]
+		[InlineData(",1000", "2,000")]
+		public void ValidateSource_ThousandBeforeComma_WithErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.Equal(errorMessage[0].ErrorMessage, PluginResources.Error_NumbersNotIdentical);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("Simple test with 1000 and a comma before second number,1000", "Simple test with 1000 and second number 1,000")]
+		public void ValidateSource_ThousandBeforeComma_CombinedNumbers_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("This is a simple test with 3000 and a comma before second number, 3000", "This is a simple test with 3000 and second number 3,000")]
+		public void ValidateSource_ThousandBeforeComma_WithSpaces_CombinedNumbers_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("This is a simple test with 3000 and a comma before second number...3000", "This is a simple test with 3000 and second number 3,000")]
+		[InlineData("This is a simple test with...*+12000 and a comma before second number...3000", "This is a simple test with 12.000 and second number 3,000")]
+		public void ValidateSource_ThousandBeforeComma_WithMultiplePunctuationMarks_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Source sep: 'No separator' checked
+		/// Target sep: 'Comma' checked
+		/// Verification error: no errors should be returned.
+		/// </summary>
+		[Theory]
+		[InlineData("This is 12,000 and 3000 and a comma before second number, 3000", "This is 12000 and 3000 and second number 3,000")]
+		public void ValidateSource_WithSpaces_CombinedNumbers_NoErrors(string source, string target)
+		{
+			//target settings
+			var numberVerifierSettings = NumberVerifierLocalizationsSettings.RequireLocalization();
+			numberVerifierSettings.Setup(t => t.TargetThousandsComma).Returns(true);
+
+			// source settings
+			numberVerifierSettings.Setup(s => s.SourceNoSeparator).Returns(true);
+			numberVerifierSettings.Setup(s => s.SourceThousandsComma).Returns(true);
+			numberVerifierSettings.Setup(s => s.CustomsSeparatorsAlphanumerics).Returns(false);
+
+			NumberVerifierLocalizationsSettings.InitSeparators(numberVerifierSettings);
+			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
+
+			//run initialize method in order to set chosen separators
+			numberVerifierMain.Initialize(_documentProperties.Object);
+
+			var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
+
+			Assert.True(errorMessage.Count == 0);
+		}
+
+		/// <summary>
+		/// Check for negative numbers
+		/// Error : number modified/unlocalized
+		/// </summary>
+		[Theory]
         [InlineData("-1 554,5", "1.554,5")]
         public void CheckNegativeNumbers(string source, string target)
         {
@@ -239,8 +446,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -251,8 +457,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Target sep -thousands : space, thin space, no-break space -decimal : comma, period
         /// Source sep - thousands: space , - decimal: period, comma
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1 554.5 some word 1 234,5 another word −1 222,3", "1 554,5 test 1 234.5 another test word -1 222,3")]
         public void ThousandsSeparatorsAllTypesOfSpaces(string source, string target)
@@ -271,8 +475,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -287,8 +490,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Target decimal: period
         /// No error
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,55", "1.55")]
         public void DecimalSeparatorsComma(string source, string target)
@@ -303,8 +504,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -316,8 +516,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Target decimal: period and Target NoSeparator option
         /// No error
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,55", "1.55")]
         public void Validate_DecimalSeparatorsComma_WhenNoSeparatorOption_IsChecked(string source, string target)
@@ -335,8 +533,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -348,8 +545,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 		/// Target decimal: comma, period
 		/// No errors
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
         [InlineData("1,55 another number 1,34", "1.55 number 1,34")]
         public void DecimalSeparatorsCommaPeriod(string source, string target)
@@ -364,8 +559,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -379,8 +573,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// <summary>
         /// Error: number modified
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1,55", "1,55")]
         public void DecimalSeparatorsCommaInsteadOfPeriodErrorMessage(string source, string target)
@@ -402,8 +594,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -413,8 +604,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// <summary>
         /// Error number removed
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1 554.5 some word 1,25", "1 554.5")]
         public void CheckForRemovedNumbers(string source, string target)
@@ -432,8 +621,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -443,8 +631,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// <summary>
         /// Error number added
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1 554.5", "1 554.5 some word 1.25")]
         public void CheckForAddedNumbers(string source, string target)
@@ -461,8 +647,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
             var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
             //run initialize method in order to set chosen separators
-            var docPropMock = new Mock<IDocumentProperties>();
-            numberVerifierMain.Initialize(docPropMock.Object);
+            numberVerifierMain.Initialize(_documentProperties.Object);
 
             var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -473,8 +658,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate text for source with no separator option and target with no-break space option.
         /// No error message returned
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("2300", "2 300")]
 		public void CheckNoSeparatorNumbers(string source, string target)
@@ -492,8 +675,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -504,8 +686,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate text for source with comma thousands option and target with no separator option.
         /// No error message returned
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("2,300", "2300")]
         public void CheckThousandCommaNoSeparatorNumbers(string source, string target)
@@ -521,8 +701,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 			var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -533,8 +712,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate text for source with No separator option and target with no separator option + Sace option enabled.
         /// No error message returned
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("2300", "2 300")]
         public void ValidateTargetSpace_NoSeparator(string source, string target)
@@ -551,8 +728,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -563,8 +739,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate text for source with No separator option and target with no separator option + Space option disabled.
         /// Validation error message returned
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("1200", "1 201")]
         public void ValidateTargetSpace_NoSeparator_Errors(string source, string target)
@@ -581,8 +755,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -594,8 +767,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate decimal text where an empty space is added within the target text
         /// Validation error message returned, because the space validation are made for thousand numbers, and not decimals
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("600", "6 00")]
         public void ValidateDecimalWithNoSpace_NoSeparator_Errors(string source, string target)
@@ -613,21 +784,17 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
 	        Assert.Equal(PluginResources.Error_NumbersNotIdentical, errorMessage[0].ErrorMessage);
         }
-
-
+		
 		/// <summary>
 		/// Validate big number containing thousand with comma and period separators
 		/// No validation error should be returned
 		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="target"></param>
 		[Theory]
         [InlineData("234,463.345", "234,463.345")]
         public void ValidateThousandNumbers_NoErrors(string source, string target)
@@ -645,8 +812,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 
@@ -657,8 +823,6 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
         /// Validate big number containing thousand with comma and period separators
         /// Validation errors should be reported
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
         [Theory]
         [InlineData("234,463.345", "234,463,345")]
         public void ValidateThousandNumbers_WithErrors(string source, string target)
@@ -676,8 +840,7 @@ namespace Sdl.Community.NumberVerifier.Tests.NormalizeNumbers
 	        var numberVerifierMain = new NumberVerifierMain(numberVerifierSettings.Object);
 
 	        //run initialize method in order to set chosen separators
-	        var docPropMock = new Mock<IDocumentProperties>();
-	        numberVerifierMain.Initialize(docPropMock.Object);
+	        numberVerifierMain.Initialize(_documentProperties.Object);
 
 	        var errorMessage = numberVerifierMain.CheckSourceAndTarget(source, target);
 

--- a/Number Verifier/Sdl.Community.NumberVerifier.Tests/OmitZero/OmitZeroSourceAndTarget.cs
+++ b/Number Verifier/Sdl.Community.NumberVerifier.Tests/OmitZero/OmitZeroSourceAndTarget.cs
@@ -164,7 +164,7 @@ namespace Sdl.Community.NumberVerifier.Tests.OmitZero
 		public void SourceOmitUncheckedTargetCheckedError(string source, string target)
 		{
 			var errorMessage = SourceOmitUncheckedTargetChecked(source, target);
-			Assert.Equal(PluginResources.Error_NumbersAdded, errorMessage[0].ErrorMessage);
+			Assert.Equal(PluginResources.Error_NumbersNotIdentical, errorMessage[0].ErrorMessage);
 		}
 
 		/// <summary>

--- a/Number Verifier/pluginpackage.manifest.xml
+++ b/Number Verifier/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDL Number Verifier</PlugInName>
-  <Version>3.0.1.2</Version>
+  <Version>3.0.2.0</Version>
   <Description>Verifies that numbers have not been changed during translation/editing.</Description>
   <Author>SDL Community Developers</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0"/>


### PR DESCRIPTION
Apply fix from Studio 2019
Update UTs
Add new UTs