### PR TITLE
RateIt

### DIFF
--- a/Code samples/RateItControl/RateItControl/RateItControl/Themes/Generic/RateItControl.cs
+++ b/Code samples/RateItControl/RateItControl/RateItControl/Themes/Generic/RateItControl.cs
@@ -293,6 +293,7 @@ namespace Sdl.Community.RateItControl.Themes.Generic
 			if (RateItControlItemsControl.SelectedItems.Count > 0)
 			{
 				Rating = RateItControlItemsControl.SelectedIndex + 1;
+				RateItControlItemsControl.SelectedIndex = -1;
 			}
 		}
 


### PR DESCRIPTION
 - reset selection index to -1 so that the user can still select every star after a programatic reset of the rating