### PR TITLE
DeepL 2021: improve app when no languages are retrieved using the DeepL server endpoint

### DIFF
--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLMtTranslationProvider.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLMtTranslationProvider.cs
@@ -87,9 +87,18 @@ namespace Sdl.Community.DeepLMTProvider
 			return JsonConvert.SerializeObject(Options);
 		}
 
+		// Check if LanguageDirection is supported (if true, the provider is added in Studio)
+		// 'IsInvalidServerMessage' is used to check if any server error was returned in the first call, if yes, then is no need to make the second call to 
+		// the server to verify if language pairs are supported. (2 calls of SupportsLanguageDirection() are made because of twice instantiation of DeepLTranslationProviderConnecter. 
 		public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{
-			return DeepLTranslationProviderConnecter.IsLanguagePairSupported(languageDirection.SourceCulture, languageDirection.TargetCulture);
+
+			if (!Helpers.IsInvalidServerMessage)
+			{
+				return DeepLTranslationProviderConnecter.IsLanguagePairSupported(languageDirection.SourceCulture, languageDirection.TargetCulture);
+			}
+
+			return false;
 		}
 	}
 }

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLMtTranslationProvider.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLMtTranslationProvider.cs
@@ -89,8 +89,7 @@ namespace Sdl.Community.DeepLMTProvider
 
 		public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{
-			return DeepLTranslationProviderConnecter.IsLanguagePairSupported(languageDirection.SourceCulture,
-				languageDirection.TargetCulture);
+			return DeepLTranslationProviderConnecter.IsLanguagePairSupported(languageDirection.SourceCulture, languageDirection.TargetCulture);
 		}
 	}
 }

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Xml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -28,8 +27,10 @@ namespace Sdl.Community.DeepLMTProvider
 
 		public bool IsLanguagePairSupported(CultureInfo sourceCulture, CultureInfo targetCulture)
 		{
-			return GetLanguage(sourceCulture, SupportedSourceLanguages) != null &&
-			       GetLanguage(targetCulture, SupportedTargetLanguages) != null;
+			var supportedSourceLanguage = GetLanguage(sourceCulture, SupportedSourceLanguages);
+			var supportedTargetLanguage = GetLanguage(targetCulture, SupportedTargetLanguages);
+
+			return !string.IsNullOrEmpty(supportedSourceLanguage) && !string.IsNullOrEmpty(supportedTargetLanguage);
 		}
 
 		public DeepLTranslationProviderConnecter(string key, Formality formality)
@@ -152,43 +153,49 @@ namespace Sdl.Community.DeepLMTProvider
 
 		private List<string> GetSupportedLanguages(string type)
 		{
-			using (var httpClient = new HttpClient())
+			try
 			{
-				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 |
-													   SecurityProtocolType.Tls;
-
-				httpClient.Timeout = TimeSpan.FromMinutes(5);
-				var content = new StringContent($"type={type}" +
-												$"&auth_key={ApiKey}",
-					Encoding.UTF8, "application/x-www-form-urlencoded");
-
-				httpClient.DefaultRequestHeaders.Add("Trace-ID", $"SDL Trados Studio 2021 /plugin {_pluginVersion}");
-
-				var response = httpClient.PostAsync("https://api.deepl.com/v2/languages", content).Result;
-				if (response.IsSuccessStatusCode)
+				using (var httpClient = new HttpClient())
 				{
-					var languagesResponse = response.Content?.ReadAsStringAsync().Result;
+					ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 
-					return JArray.Parse(languagesResponse).Select(item => item["language"].ToString().ToUpperInvariant()).ToList();
+					httpClient.Timeout = TimeSpan.FromMinutes(5);
+					var content = new StringContent($"type={type}" + $"&auth_key={ApiKey}", Encoding.UTF8, "application/x-www-form-urlencoded");
+
+					httpClient.DefaultRequestHeaders.Add("Trace-ID", $"SDL Trados Studio 2021 /plugin {_pluginVersion}");
+
+					var response = httpClient.PostAsync("https://api.deepl.com/v2/languages", content).Result;
+					if (response.IsSuccessStatusCode)
+					{
+						var languagesResponse = response.Content?.ReadAsStringAsync().Result;
+
+						return JArray.Parse(languagesResponse).Select(item => item["language"].ToString().ToUpperInvariant()).ToList();
+					}
 				}
 			}
+			catch (Exception ex)
+			{
+				_logger.Error($"{ex}");
+			}
 
-			return null;
+			return new List<string>();
 		}
 
 		// Get the target language based on availability in DeepL; if we have a flavour use that, otherwise use general culture of that flavour (two letter iso) if available, otherwise return null
 		// (e.g. for Portuguese, the leftLanguageTag (pt-PT or pt-BR) should be used, so the translations will correspond to the specific language flavor)
 		private string GetLanguage(CultureInfo culture, List<string> languageList)
 		{
-			var leftLangTag = culture.IetfLanguageTag.ToUpperInvariant();
-			var twoLetterIso = culture.TwoLetterISOLanguageName.ToUpperInvariant();
+			if (languageList != null && languageList.Any())
+			{
+				var leftLangTag = culture.IetfLanguageTag.ToUpperInvariant();
+				var twoLetterIso = culture.TwoLetterISOLanguageName.ToUpperInvariant();
 
-			var selectedTargetLanguage = languageList.FirstOrDefault(tl => tl == leftLangTag) ??
-			                             languageList.FirstOrDefault(tl => tl == twoLetterIso);
+				var selectedTargetLanguage = languageList.FirstOrDefault(tl => tl == leftLangTag) ?? languageList.FirstOrDefault(tl => tl == twoLetterIso);
 
-			return selectedTargetLanguage ?? (languageList.Any(tl => tl.Contains(twoLetterIso))
-				? twoLetterIso
-				: null);
+				return selectedTargetLanguage ?? (languageList.Any(tl => tl.Contains(twoLetterIso)) ? twoLetterIso : null);
+			}
+
+			return string.Empty;
 		}
 	}
 }

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/DeepLTranslationProviderConnecter.cs
@@ -28,7 +28,8 @@ namespace Sdl.Community.DeepLMTProvider
 		public bool IsLanguagePairSupported(CultureInfo sourceCulture, CultureInfo targetCulture)
 		{
 			var supportedSourceLanguage = GetLanguage(sourceCulture, SupportedSourceLanguages);
-			var supportedTargetLanguage = GetLanguage(targetCulture, SupportedTargetLanguages);
+			// do not make a call again to the server if source languages are not supported, because the return condition requires both source and target languages to be supported
+			var supportedTargetLanguage = !string.IsNullOrEmpty(supportedSourceLanguage) ? GetLanguage(targetCulture, SupportedTargetLanguages) : string.Empty;
 
 			return !string.IsNullOrEmpty(supportedSourceLanguage) && !string.IsNullOrEmpty(supportedTargetLanguage);
 		}
@@ -64,11 +65,9 @@ namespace Sdl.Community.DeepLMTProvider
 
 		public string ApiKey { get; set; }
 
-		private List<string> SupportedTargetLanguages
-			=> _supportedTargetLanguages ?? (_supportedTargetLanguages = GetSupportedLanguages("target"));
+		private List<string> SupportedTargetLanguages => _supportedTargetLanguages ?? (_supportedTargetLanguages = GetSupportedLanguages("target"));
 
-		private List<string> SupportedSourceLanguages
-			=> _supportedSourceLanguages ?? (_supportedSourceLanguages = GetSupportedLanguages("source"));
+		private List<string> SupportedSourceLanguages => _supportedSourceLanguages ?? (_supportedSourceLanguages = GetSupportedLanguages("source"));
 
 		public string Translate(LanguagePair languageDirection, string sourceText)
 		{
@@ -165,6 +164,10 @@ namespace Sdl.Community.DeepLMTProvider
 					httpClient.DefaultRequestHeaders.Add("Trace-ID", $"SDL Trados Studio 2021 /plugin {_pluginVersion}");
 
 					var response = httpClient.PostAsync("https://api.deepl.com/v2/languages", content).Result;
+
+					// show server message in case the response is not successfully retrieved
+					Helpers.DisplayServerMessage(response);
+
 					if (response.IsSuccessStatusCode)
 					{
 						var languagesResponse = response.Content?.ReadAsStringAsync().Result;

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>DeepL Translation Provider</PlugInName>
-  <Version>5.8.18.0</Version>
+  <Version>5.8.18.1</Version>
   <Description>This plugin provides machine translation results from the DeepL Translator.</Description>
   <Author>SDL Community Developers</Author>
   <Include>

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>DeepL Translation Provider</PlugInName>
-  <Version>5.8.17.1</Version>
+  <Version>5.8.18.0</Version>
   <Description>This plugin provides machine translation results from the DeepL Translator.</Description>
   <Author>SDL Community Developers</Author>
   <Include>

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/Helpers.cs
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/Helpers.cs
@@ -1,6 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Windows.Forms;
+using Sdl.Community.DeepLMTProvider.WPF;
 
 namespace Sdl.Community.DeepLMTProvider
 {
@@ -15,6 +19,9 @@ namespace Sdl.Community.DeepLMTProvider
 			"en-gb",
 			"en-us",
 		};
+
+		public static bool IsInvalidServerMessage { get; set; }
+
 		public static bool AreLanguagesCompatibleWithFormalityParameter(List<CultureInfo> targetLanguages)
 		{
 			return targetLanguages.All(IsLanguageCompatible);
@@ -24,6 +31,25 @@ namespace Sdl.Community.DeepLMTProvider
 		{
 			var twoLetterIsoLanguage = targetLanguage.TwoLetterISOLanguageName.ToLowerInvariant();
 			return !FormalityIncompatibleTargetLanguages.Contains(twoLetterIsoLanguage);
+		}
+
+		public static void DisplayServerMessage(HttpResponseMessage response)
+		{
+			if (response.StatusCode == HttpStatusCode.Forbidden)
+			{
+				MessageBox.Show(PluginResources.Forbidden_Message, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+				IsInvalidServerMessage = true;
+				return;
+			}
+
+			if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.Forbidden)
+			{
+				MessageBox.Show(string.Format(PluginResources.ServerGeneralResponse_Message, response.StatusCode.ToString()), string.Empty, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+				IsInvalidServerMessage = true;
+				return;
+			}
+
+			IsInvalidServerMessage = false;
 		}
 	}
 }

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.Designer.cs
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sdl.Community.DeepLMTProvider.WPF {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Looks up a localized string similar to The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key..
+        /// </summary>
+        public static string Forbidden_Message {
+            get {
+                return ResourceManager.GetString("Forbidden_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sets whether the translated text should lean towards formal or informal language.
         ///This feature currently works for all target languages except &quot;ES&quot; (Spanish), &quot;JA&quot; (Japanese) and &quot;ZH&quot; (Chinese)..
         /// </summary>
@@ -76,6 +85,15 @@ namespace Sdl.Community.DeepLMTProvider.WPF {
         public static string FormalityNotAvailableText {
             get {
                 return ResourceManager.GetString("FormalityNotAvailableText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Looks up a localized string similar to The DeepL provider is returning a &amp;apos;{0}&amp;apos; status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity..
+        /// </summary>
+        public static string ServerGeneralResponse_Message {
+            get {
+                return ResourceManager.GetString("ServerGeneralResponse_Message", resourceCulture);
             }
         }
         

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.Designer.cs
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.Designer.cs
@@ -61,7 +61,7 @@ namespace Sdl.Community.DeepLMTProvider.WPF {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Looks up a localized string similar to The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key..
+        ///   Looks up a localized string similar to The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key..
         /// </summary>
         public static string Forbidden_Message {
             get {
@@ -89,7 +89,7 @@ namespace Sdl.Community.DeepLMTProvider.WPF {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Looks up a localized string similar to The DeepL provider is returning a &amp;apos;{0}&amp;apos; status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity..
+        ///   Looks up a localized string similar to The DeepL provider is returning a &apos;{0}&apos; status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity..
         /// </summary>
         public static string ServerGeneralResponse_Message {
             get {

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.resx
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.resx
@@ -137,9 +137,9 @@ This feature currently works for all target languages except "ES" (Spanish), "JA
     <value>*Not all languages are compatible with this option...</value>
   </data>
   <data name="Forbidden_Message" xml:space="preserve">
-    <value>Looks up a localized string similar to The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key.</value>
+    <value>The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key.</value>
   </data>
   <data name="ServerGeneralResponse_Message" xml:space="preserve">
-    <value>Looks up a localized string similar to The DeepL provider is returning a &amp;apos;{0}&amp;apos; status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity.</value>
+    <value>The DeepL provider is returning a '{0}' status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity.</value>
   </data>
 </root>

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.resx
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/PluginResources.resx
@@ -124,15 +124,22 @@
     <value>Minimize</value>
   </data>
   <data name="SettingsUpdated_ReopenFilesForEditing" xml:space="preserve">
-	  <value>In order for the new settings to take effect, you have to reopen the file for editing</value>
+    <value>In order for the new settings to take effect, you have to reopen the file for editing</value>
   </data>
   <data name="SettingsUpdated" xml:space="preserve">
-	  <value>Settings Updated</value>
+    <value>Settings Updated</value>
   </data>
   <data name="FormalityNotAvailableReason" xml:space="preserve">
-	  <value>Sets whether the translated text should lean towards formal or informal language.&#10;This feature currently works for all target languages except "ES" (Spanish), "JA" (Japanese) and "ZH" (Chinese).</value>
+    <value>Sets whether the translated text should lean towards formal or informal language.
+This feature currently works for all target languages except "ES" (Spanish), "JA" (Japanese) and "ZH" (Chinese).</value>
   </data>
   <data name="FormalityNotAvailableText" xml:space="preserve">
-	  <value>*Not all languages are compatible with this option...</value>
+    <value>*Not all languages are compatible with this option...</value>
+  </data>
+  <data name="Forbidden_Message" xml:space="preserve">
+    <value>Looks up a localized string similar to The DeepL provider is returning a 403 forbidden status. This means there is a problem with your API key accessing the services you have requested. Please check you have a valid API key.</value>
+  </data>
+  <data name="ServerGeneralResponse_Message" xml:space="preserve">
+    <value>Looks up a localized string similar to The DeepL provider is returning a &amp;apos;{0}&amp;apos; status. This means is a problem on accessing the services you have requested. Please check you have a valid API key and also the internet connectivity.</value>
   </data>
 </root>

--- a/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/Sdl.Community.DeepLMTProvider.WPF.csproj
+++ b/DeepLMTProvider/Sdl.Community.DeepLMTProvider.WPF/Sdl.Community.DeepLMTProvider.WPF.csproj
@@ -78,6 +78,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Add validations to avoid the app crash when no languages are retrieved from the DeepL server.
Add logging to method which retrieves languages from the DeepL server.
Display custom message when languages are not retrieved from the server and the app cannot be added as provider.