### PR TITLE
Fix problem when replacing words which contains symbols using Regex

### DIFF
--- a/Toolkit/SDLXLIFFSliceOrChange/ReplaceManager.cs
+++ b/Toolkit/SDLXLIFFSliceOrChange/ReplaceManager.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using log4net;
-
-//using Sdl.Utilities.BatchSearchReplace.Lib;
 
 namespace SDLXLIFFSliceOrChange
 {
@@ -20,29 +19,29 @@ namespace SDLXLIFFSliceOrChange
 			{
 				sdlxliffSliceOrChange.StepProcess("Replaceing in file: " + file + "...");
 
-				String fileContent = String.Empty;
-				using (StreamReader sr = new StreamReader(file))
+				var fileContent = string.Empty;
+				using (var sr = new StreamReader(file))
 				{
 					fileContent = sr.ReadToEnd();
 				}
 				fileContent = Regex.Replace(fileContent, "\t", "");
 
-				using (StreamWriter sw = new StreamWriter(file, false))
+				using (var sw = new StreamWriter(file, false))
 				{
 					sw.Write(fileContent);
 				}
 
-				XmlDocument xDoc = new XmlDocument();
+				var xDoc = new XmlDocument();
 				xDoc.PreserveWhitespace = true;
 				xDoc.Load(file);
 
-				String xmlEncoding = "utf-8";
+				var xmlEncoding = "utf-8";
 				try
 				{
 					if (xDoc.FirstChild.NodeType == XmlNodeType.XmlDeclaration)
 					{
 						// Get the encoding declaration.
-						XmlDeclaration decl = (XmlDeclaration)xDoc.FirstChild;
+						var decl = (XmlDeclaration)xDoc.FirstChild;
 						xmlEncoding = decl.Encoding;
 					}
 				}
@@ -51,81 +50,66 @@ namespace SDLXLIFFSliceOrChange
 					logger.Error(ex.Message, ex);
 				}
 
-				XmlNodeList fileList = xDoc.DocumentElement.GetElementsByTagName("file");
-				foreach (XmlElement fileElement in fileList.OfType<XmlElement>())
+				var fileList = xDoc.DocumentElement.GetElementsByTagName("file");
+				foreach (var fileElement in fileList.OfType<XmlElement>())
 				{
-					XmlElement bodyElement = (XmlElement)(fileElement.GetElementsByTagName("body")[0]);
-					XmlNodeList groupElements = bodyElement.GetElementsByTagName("group");
+					var bodyElement = (XmlElement)(fileElement.GetElementsByTagName("body")[0]);
+					var groupElements = bodyElement.GetElementsByTagName("group");
 
 					foreach (var groupElement in groupElements.OfType<XmlElement>())
 					{
 						//look in segments
-						XmlNodeList transUnits = ((XmlElement)groupElement).GetElementsByTagName("trans-unit");
-						foreach (XmlElement transUnit in transUnits.OfType<XmlElement>())
+						var transUnits = ((XmlElement)groupElement).GetElementsByTagName("trans-unit");
+						foreach (var transUnit in transUnits.OfType<XmlElement>())
 						{
-							XmlNodeList source = transUnit.GetElementsByTagName("source");
+							var source = transUnit.GetElementsByTagName("source");
 							if (source.Count > 0) //in mrk, g si innertext
 								ReplaceAllChildsValue((XmlElement)source[0], settings);
-							source = null;
-							XmlNodeList segSource = transUnit.GetElementsByTagName("seg-source");
+							var segSource = transUnit.GetElementsByTagName("seg-source");
 							if (segSource.Count > 0) //in mrk, g si innertext
 								ReplaceAllChildsValue((XmlElement)segSource[0], settings);
-							segSource = null;
-							XmlNodeList target = transUnit.GetElementsByTagName("target");
+							var target = transUnit.GetElementsByTagName("target");
 							if (target.Count > 0) //in mrk, g si innertext
 								ReplaceAllChildsValue((XmlElement)target[0], settings, false);
-							target = null;
 						}
 					}
 
 					//look in segments not located in groups
-					XmlNodeList transUnitsInBody = bodyElement.ChildNodes;//.GetElementsByTagName("trans-unit");
-					foreach (XmlElement transUnit in transUnitsInBody.OfType<XmlElement>())
+					var transUnitsInBody = bodyElement.ChildNodes;//.GetElementsByTagName("trans-unit");
+					foreach (var transUnit in transUnitsInBody.OfType<XmlElement>())
 					{
 						if (transUnit.Name != "trans-unit")
 							continue;
-						XmlNodeList source = transUnit.GetElementsByTagName("source");
+						var source = transUnit.GetElementsByTagName("source");
 						if (source.Count > 0) //in mrk, g si innertext
 							ReplaceAllChildsValue((XmlElement)source[0], settings);
-						source = null;
-						XmlNodeList segSource = transUnit.GetElementsByTagName("seg-source");
+						var segSource = transUnit.GetElementsByTagName("seg-source");
 						if (segSource.Count > 0) //in mrk, g si innertext
 							ReplaceAllChildsValue((XmlElement)segSource[0], settings);
-						segSource = null;
-						XmlNodeList target = transUnit.GetElementsByTagName("target");
+						var target = transUnit.GetElementsByTagName("target");
 						if (target.Count > 0) //in mrk, g si innertext
 							ReplaceAllChildsValue((XmlElement)target[0], settings, false);
-						target = null;
 					}
-
-					bodyElement = null;
-					groupElements = null;
-					transUnitsInBody = null;
 				}
 				Encoding encoding = new UTF8Encoding();
-				if (!String.IsNullOrEmpty(xmlEncoding))
+				if (!string.IsNullOrEmpty(xmlEncoding))
 					encoding = Encoding.GetEncoding(xmlEncoding);
 
 				using (var writer = new XmlTextWriter(file, encoding))
 				{
-					////writer.Formatting = Formatting.None;
 					xDoc.Save(writer);
 				}
 
-				fileContent = String.Empty;
-				using (StreamReader sr = new StreamReader(file))
+				using (var sr = new StreamReader(file))
 				{
 					fileContent = sr.ReadToEnd();
 				}
 				fileContent = Regex.Replace(fileContent, "", "\t");
 
-				using (StreamWriter sw = new StreamWriter(file, false))
+				using (var sw = new StreamWriter(file, false))
 				{
 					sw.Write(fileContent);
 				}
-
-				xDoc = null;
-				fileList = null;
 				sdlxliffSliceOrChange.StepProcess("All information replaced in file: " + file + ".");
 			}
 			catch (Exception ex)
@@ -140,9 +124,9 @@ namespace SDLXLIFFSliceOrChange
 
 			foreach (var innerChild in childNodes)
 			{
-				if (innerChild.Name == "mrk" && innerChild.HasAttribute("mtype"))
+				if (innerChild.Name.Equals("mrk") && innerChild.HasAttribute("mtype"))
 				{
-					ReplaceTheVaue(settings, inSource, innerChild);
+					ReplaceValue(settings, inSource, innerChild);
 				}
 				GetLastNode(settings, inSource, innerChild);
 			}
@@ -150,13 +134,13 @@ namespace SDLXLIFFSliceOrChange
 
 		private static void ReplaceAllChildsValue(XmlElement target, ReplaceSettings settings, bool inSource = true)
 		{
-			foreach (XmlElement child in target.ChildNodes.OfType<XmlElement>())
+			foreach (var child in target.ChildNodes.OfType<XmlElement>())
 			{
 				if (!child.IsEmpty)
 				{
-					if (child.Name == "mrk" && child.HasAttribute("mtype"))
+					if (child.Name.Equals("mrk") && child.HasAttribute("mtype"))
 					{
-						ReplaceTheVaue(settings, inSource, child);
+						ReplaceValue(settings, inSource, child);
 					}
 					else
 					{
@@ -165,46 +149,47 @@ namespace SDLXLIFFSliceOrChange
 				}
 			}
 		}
-		private static void ReplaceTheVaue(ReplaceSettings settings, bool inSource, XmlElement child)
+
+		private static void ReplaceValue(ReplaceSettings settings, bool inSource, XmlElement child)
 		{
 			var segmentHtml = child.InnerXml;
-
-			if (settings.UseRegEx)
+			if (!string.IsNullOrEmpty(segmentHtml))
 			{
-				var options = RegexOptions.None & RegexOptions.Multiline;
-
-				if (!settings.MatchCase)
-					options = RegexOptions.IgnoreCase & RegexOptions.Multiline;
-
-				if (segmentHtml != string.Empty)
+				if (settings.UseRegEx)
 				{
-					if (inSource && settings.SourceSearchText != string.Empty &&
-						settings.SourceReplaceText != string.Empty)
+					var options = !settings.MatchCase ? RegexOptions.IgnoreCase & RegexOptions.Multiline : RegexOptions.None & RegexOptions.Multiline;
+
+					if (!string.IsNullOrEmpty(segmentHtml))
 					{
-						var sourceRg = new Regex(settings.SourceSearchText, options);
-						var replacedText = sourceRg.Replace(segmentHtml, settings.SourceReplaceText);
-						child.InnerXml = replacedText;
-					}
-					if (!inSource && settings.TargetSearchText != string.Empty)
-					{
-						var targetRg = new Regex(settings.TargetSearchText, options);
-						var replacedText = targetRg.Replace(segmentHtml, settings.TargetReplaceText);
-						child.InnerXml = replacedText;
+						ReplaceRegexText(settings, options, segmentHtml, child, inSource);
 					}
 				}
-			}
-			else
-			{
-				if (segmentHtml != string.Empty)
+				else
 				{
 					var remove = Regex.Escape(inSource ? settings.SourceSearchText : settings.TargetSearchText);
-					var pattern = settings.MatchWholeWord
-											 ? string.Format(@"(\b(?<!\w){0}\b|(?<=^|\s){0}(?=\s|$))", remove)
-											 : remove;
+					var pattern = settings.MatchWholeWord ? string.Format(@"(\b(?<!\w){0}\b|(?<=^|\s){0}(?=\s|$))", remove) : remove;
 					var replace = inSource ? settings.SourceReplaceText : settings.TargetReplaceText;
-					child.InnerXml = Regex.Replace(segmentHtml, pattern, replace,
-														!settings.MatchCase ? RegexOptions.IgnoreCase : RegexOptions.None);
+					child.InnerXml = Regex.Replace(segmentHtml, pattern, replace, !settings.MatchCase ? RegexOptions.IgnoreCase : RegexOptions.None);
 				}
+			}
+		}
+
+		// Replace the text indentified by Regex.
+		// SegmentHtml needs to be encoded, because the settings.SourceReplaceText/settings.TargetReplaceText is encoded
+		// and it should be the same for a correct replacement (ex: words which contains symbols)
+		private static void ReplaceRegexText(ReplaceSettings settings, RegexOptions options, string segmentHtml, XmlElement child, bool inSource)
+		{
+			if (inSource && !string.IsNullOrEmpty(settings.SourceSearchText) && !string.IsNullOrEmpty(settings.SourceReplaceText))
+			{
+				var sourceRg = new Regex(settings.SourceSearchText, options);
+				var replacedText = sourceRg.Replace(WebUtility.HtmlEncode(segmentHtml), settings.SourceReplaceText);
+				child.InnerXml = replacedText;
+			}
+			if (!inSource && !string.IsNullOrEmpty(settings.TargetSearchText))
+			{
+				var targetRg = new Regex(settings.TargetSearchText, options);
+				var replacedText = targetRg.Replace(WebUtility.HtmlEncode(segmentHtml), settings.TargetReplaceText);
+				child.InnerXml = replacedText;
 			}
 		}
 	}

--- a/Toolkit/SDLXLIFFSliceOrChange/ResourceManager/UIResources.cs
+++ b/Toolkit/SDLXLIFFSliceOrChange/ResourceManager/UIResources.cs
@@ -9,7 +9,7 @@ namespace SDLXLIFFSliceOrChange.ResourceManager
     public class UIResources
     {
         #region public props
-        private Dictionary<String, String> _defaultValues; 
+        private Dictionary<string, string> _defaultValues; 
 
         public string Browse { get { return GetString("Browse"); } }
         public string Slice { get { return GetString("Slice"); } }
@@ -110,7 +110,7 @@ namespace SDLXLIFFSliceOrChange.ResourceManager
 
         private DataSet _resources;
 
-        public UIResources(String culture)
+        public UIResources(string culture)
         {
             try
             {
@@ -210,30 +210,31 @@ namespace SDLXLIFFSliceOrChange.ResourceManager
             if (_resources == null)
             {
                 _resources = new DataSet();
-                _resources.ReadXml(String.Format(File, _culture));
+                _resources.ReadXml(string.Format(File, _culture));
             }
         }
 
-        public String GetString(String token)
-        {
-            if (_resources == null) return Getefault(token);
-            try
-            {
-                DataTable values = _resources.Tables["data"];
-                DataRow[] rows = values.Select(String.Format("name = '{0}'", token));
-                if (rows.Length == 0)
-                {
-                    return Getefault(token);
-                }
-                return rows[0]["Value"].ToString();
+		public string GetString(string token)
+		{
+			if (_resources == null) return GetDefault(token);
+			try
+			{
+				var values = _resources.Tables["data"];
+				var rows = values.Select($"name = '{token}'");
+				if (rows.Length == 0)
+				{
+					return GetDefault(token);
+				}
+				return rows[0]["Value"].ToString();
 
-            } catch
-            {
-                return Getefault(token);
-            }
-        }
-
-        private string Getefault(string token)
+			}
+			catch
+			{
+				return GetDefault(token);
+			}
+		}
+		
+		private string GetDefault(string token)
         {
             if (_defaultValues != null && _defaultValues.ContainsKey(token)) return _defaultValues[token];
             return token;

--- a/Toolkit/SdlXliffToolkit/pluginpackage.manifest.xml
+++ b/Toolkit/SdlXliffToolkit/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDLXLIFF Toolkit</PlugInName>
-  <Version>4.1.5.1</Version>
+  <Version>4.1.6.0</Version>
   <Description>SdlXliffToolkit</Description>
 	<Author>SDL Community Developers</Author>
   <Include>


### PR DESCRIPTION
Fix problem when replacing words which contains symbols using Regex: Encode the segmentHtml for the correct replacement
Rename the ReplaceTheValue method with ReplaceValue and refactor
Update plugin's version