### PR TITLE
Tina master branch 2021: Update the UpgradeCode

### DIFF
--- a/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/defines.wxi
+++ b/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/defines.wxi
@@ -3,7 +3,7 @@
   <?define productVersion = "3.0.1.2"?>
   <?define versionedName = "Studio16"?>
   <!--Upgrade code only change per new baseline (rtm or SP release).-->
-  <?define upgradeCode = "4D8ED4AB-A267-4E57-9EDF-783DD990E9DE"?>
+  <?define upgradeCode = "F6741828-198D-43B2-A0F8-2D96C5443390"?>
   <?define AppName = "HunspellDictionaryManager"?>
 
   <!--InstallFolder=Studio16;Version=3.0.1.2;StudioVersion=16;Manufacturer=SDL Community;AppName=HunspellDictionaryManager;SourcePath=../build-->


### PR DESCRIPTION
Put back the UpgradeCode which was initially added at the migration to 2021 
!!! It is important to use the same UpgradeCode as the one from the AppStore HunspellDicitonary version, so the new instsallers genereated by the pipeline will overrite the installed AppStore version correctly and it will not duplicate the app.