### PR TITLE
Use the UpgradeCode from the defines.wxi file (as it is also on Studio 2021)

### DIFF
--- a/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/Product.wxs
+++ b/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/Product.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?include Defines.wxi ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Hunspell Dictionary Manager 2019" Language="1033" Version="$(var.productVersion)" Manufacturer="Sdl Community" UpgradeCode="97aec717-1fa7-4ebf-b1b1-893b9a45be61">
+  <Product Id="*" Name="Hunspell Dictionary Manager 2019" Language="1033" Version="$(var.productVersion)" Manufacturer="Sdl Community" UpgradeCode="$(var.upgradeCode)">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
     <Icon Id="icon.ico" SourceFile="$(var.ProjectDir)icon.ico" />

--- a/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/defines.wxi
+++ b/HunspellDictionaryManager/Sdl.Community.HunspellDictionaryManager.Installer/defines.wxi
@@ -3,7 +3,7 @@
   <?define productVersion = "2.0.1.0"?>
   <?define versionedName = "Studio15"?>
   <!--Upgrade code only change per new baseline (rtm or SP release).-->
-  <?define upgradeCode = "48BD1197-2EED-47A0-87FF-B2B1B84A5B73"?>
+  <?define upgradeCode = "97aec717-1fa7-4ebf-b1b1-893b9a45be61"?>
   <?define AppName = "HunspellDictionaryManager"?>
 
   <!--InstallFolder=Studio16;Version=3.0.1.2;StudioVersion=16;Manufacturer=SDL Community;AppName=HunspellDictionaryManager;SourcePath=../build-->


### PR DESCRIPTION
Update the defines.wxi file to use the correct UpgradeCode value (the one which is also used on the version from AppStore OOS