### PR TITLE
SDL Batch Anonymizer 2.0.4.0 -> 2.0.5.0

### DIFF
--- a/SDLBatchAnonymize/SDLBatchAnonymize/BatchAnonymizerTask.cs
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/BatchAnonymizerTask.cs
@@ -7,6 +7,7 @@ using Sdl.FileTypeSupport.Framework.Core.Utilities.BilingualApi;
 using Sdl.FileTypeSupport.Framework.IntegrationApi;
 using Sdl.ProjectAutomation.AutomaticTasks;
 using Sdl.ProjectAutomation.Core;
+using Sdl.ProjectAutomation.FileBased;
 using Sdl.TranslationStudioAutomation.IntegrationApi;
 
 
@@ -40,7 +41,7 @@ namespace Sdl.Community.SDLBatchAnonymize
 			{
 				foreach (Window window in Application.Current.Windows)
 				{
-					if (!window.Title.Equals("Batch Processing")) continue;
+					if (!window.Title.Equals("Batch Processing") && !window.Title.Contains("Create a New Project")) continue;
 					_batchTaskWindow = window;
 					_batchTaskWindow.Closing += Window_Closing;
 				}
@@ -95,9 +96,8 @@ namespace Sdl.Community.SDLBatchAnonymize
 
 			var anonymizeProjService = new AnonymizeSdlProjService();
 			var projectController = SdlTradosStudio.Application.GetController<ProjectsController>();
-			var proj = projectController.CurrentProject;
 
-			if (proj != null)
+			if (Project is FileBasedProject proj)
 			{
 				proj.Save();
 				projectController.Close(proj);

--- a/SDLBatchAnonymize/SDLBatchAnonymize/BatchAnonymizerTask.cs
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/BatchAnonymizerTask.cs
@@ -64,7 +64,7 @@ namespace Sdl.Community.SDLBatchAnonymize
 				projectController.Close(proj);
 				//Remove the comment and task template id any way
 				anonymizeProjService.RemoveFileVersionComment(projectFilePath);
-				anonymizeProjService.RemoveTemplateId(projectFilePath);
+				anonymizeProjService.RemoveTraces(projectFilePath);
 
 				projectController.Add(projectFilePath);
 			}

--- a/SDLBatchAnonymize/SDLBatchAnonymize/Interface/IAnonymizeSdlProj.cs
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/Interface/IAnonymizeSdlProj.cs
@@ -5,6 +5,6 @@ namespace Sdl.Community.SDLBatchAnonymize.Interface
 	public interface IAnonymizeSdlProj
 	{
 		void RemoveFileVersionComment(string projectPath);
-		void RemoveTemplateId(string projectPath);
+		void RemoveTraces(string projectPath);
 	}
 }

--- a/SDLBatchAnonymize/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymize.csproj
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymize.csproj
@@ -183,6 +183,9 @@
     <PackageReference Include="Sdl.Core.PluginFramework.Build">
       <Version>16.0.1</Version>
     </PackageReference>
+    <PackageReference Include="System.Xml.XDocument">
+      <Version>4.3.0</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <CreatePluginPackage>true</CreatePluginPackage>

--- a/SDLBatchAnonymize/SDLBatchAnonymize/Service/AnonymizeSdlProjService.cs
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/Service/AnonymizeSdlProjService.cs
@@ -49,13 +49,17 @@ namespace Sdl.Community.SDLBatchAnonymize.Service
 			sdlProj.Save(projectPath);
 		}
 
-		public void RemoveTemplateId(string projectPath)
+		public void RemoveTraces(string projectPath)
 		{
 			var taskTemplateId = "SDL Batch Anonymizer";
 			var rootElement = XElement.Load(projectPath);
 			
 			rootElement.Element("Tasks")?.Elements()
 				.FirstOrDefault(el=>el.Value == taskTemplateId)
+				?.Remove();
+
+			rootElement.Element("InitialTaskTemplate")?.Elements().Elements()
+				.FirstOrDefault(el => el.Attribute("TaskTemplateId")?.Value == taskTemplateId)
 				?.Remove();
 
 			rootElement.Save(projectPath);

--- a/SDLBatchAnonymize/SDLBatchAnonymize/Service/AnonymizeSdlProjService.cs
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/Service/AnonymizeSdlProjService.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Xml;
+using System.Xml.Linq;
 using Sdl.Community.SDLBatchAnonymize.Interface;
+using System.Linq;
 
 namespace Sdl.Community.SDLBatchAnonymize.Service
 {
@@ -49,35 +51,14 @@ namespace Sdl.Community.SDLBatchAnonymize.Service
 
 		public void RemoveTemplateId(string projectPath)
 		{
-			var taskTemplateId = "SDL Batch Anonymizer".ToLower();
-			var sdlProj = new XmlDocument();
-			sdlProj.Load(projectPath);
-			var tasksNodes = sdlProj.GetElementsByTagName("Tasks");
-			foreach (XmlNode taskNode in tasksNodes)
-			{
-				foreach (XmlNode taskChild in taskNode.ChildNodes)
-				{
-					var templateIdsNode = taskChild.SelectSingleNode("TaskTemplateIds");
-					if (templateIdsNode is null) continue;
-					foreach (XmlNode templateChild in templateIdsNode.ChildNodes)
-					{
-						for (var i = 0; i < templateChild.ChildNodes.Count; i++)
-						{
-							var templateChildNode = templateIdsNode.ChildNodes[i];
-							for (var j = 0; j < templateChildNode.ChildNodes.Count; j++)
-							{
-								var node = templateChildNode.ChildNodes[j];
-								if (string.IsNullOrEmpty(node.Value)) continue;
-								if (node.Value.ToLower().Equals(taskTemplateId))
-								{
-									node.ParentNode?.RemoveChild(node);
-								}
-							}
-						}
-					}
-				}
-			}
-			sdlProj.Save(projectPath);
+			var taskTemplateId = "SDL Batch Anonymizer";
+			var rootElement = XElement.Load(projectPath);
+			
+			rootElement.Element("Tasks")?.Elements()
+				.FirstOrDefault(el=>el.Value == taskTemplateId)
+				?.Remove();
+
+			rootElement.Save(projectPath);
 		}
 	}
 }

--- a/SDLBatchAnonymize/SDLBatchAnonymize/pluginpackage.manifest.xml
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDL Batch Anonymizer</PlugInName>
-  <Version>2.0.4.0</Version>
+  <Version>2.0.5.0</Version>
   <Description>Provides various options for anonymizing the files in a Studio project.</Description>
   <Author>SDL Community Developers</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0"/>

--- a/SDLBatchAnonymize/SDLBatchAnonymize/pluginpackage.manifest.xml
+++ b/SDLBatchAnonymize/SDLBatchAnonymize/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDL Batch Anonymizer</PlugInName>
-  <Version>2.0.5.0</Version>
+  <Version>2.0.5.1</Version>
   <Description>Provides various options for anonymizing the files in a Studio project.</Description>
   <Author>SDL Community Developers</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0"/>

--- a/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/AnonymizeSdlProjServiceUnitTest.cs
+++ b/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/AnonymizeSdlProjServiceUnitTest.cs
@@ -13,7 +13,7 @@ namespace Sdl.Community.SDLBatchAnonymizeUT
 		}
 
 		[Theory]
-		[InlineData(@"C:\Users\aghisa\Documents\Studio 2019\Projects\AnonDel\AnonDel.sdlproj")]
+		[InlineData(@"C:\Code\SDLCOM - Studio 2021\SDLBatchAnonymize\Sdl.Community.SDLBatchAnonymizeUT\Project 1\Project 1.sdlproj")]
 		public void AnonymizeFileVersions(string projectPath)
 		{
 			_anonymizeSdlProjService.RemoveFileVersionComment(projectPath);

--- a/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/AnonymizeSdlProjServiceUnitTest.cs
+++ b/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/AnonymizeSdlProjServiceUnitTest.cs
@@ -17,7 +17,7 @@ namespace Sdl.Community.SDLBatchAnonymizeUT
 		public void AnonymizeFileVersions(string projectPath)
 		{
 			_anonymizeSdlProjService.RemoveFileVersionComment(projectPath);
-			_anonymizeSdlProjService.RemoveTemplateId(projectPath);
+			_anonymizeSdlProjService.RemoveTraces(projectPath);
 		}
 	}
 }

--- a/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/Sdl.Community.SDLBatchAnonymizeUT.csproj
+++ b/SDLBatchAnonymize/Sdl.Community.SDLBatchAnonymizeUT/Sdl.Community.SDLBatchAnonymizeUT.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Sdl.Community.SDLBatchAnonymizeUT</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>


### PR DESCRIPTION
 - fixes issue regarding the batch task name not being removed from Task History
 - fixes issue regarding Batch Anonymizer added at project creation (projectController.CurrentProject returns null)