### PR TITLE
SDL MT Cloud: Rateit View

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/MTCloudApplicationInitializer.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/MTCloudApplicationInitializer.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Http.Headers;
+using Sdl.Community.MTCloud.Provider.Service;
+using Sdl.Community.MTCloud.Provider.Service.Interface;
+using Sdl.Desktop.IntegrationApi;
+using Sdl.Desktop.IntegrationApi.Extensions;
+
+namespace Sdl.Community.MTCloud.Provider
+{
+	[ApplicationInitializer]
+	internal class MTCloudApplicationInitializer : IApplicationInitializer
+	{
+		public static IHttpClient Client { get; private set; }
+
+		public void Execute()
+		{
+			Client = new HttpClient();
+			Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+		}
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Rating.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Rating.cs
@@ -7,5 +7,11 @@ namespace Sdl.Community.MTCloud.Provider.Model
 		public int Score { get; set; }
 		// Corresponds to the options (checkboxes) set on the UI
 		public List<string> Comments { get; set; }
+
+		public void Empty()
+		{
+			Score = 0;
+			Comments = new List<string>();
+		}
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Model\TranslationResponseStats.cs" />
     <Compile Include="Model\TranslationResponseStatus.cs" />
     <Compile Include="Model\UserCredential.cs" />
+    <Compile Include="MTCloudApplicationInitializer.cs" />
     <Compile Include="PluginResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -206,6 +207,8 @@
     <Compile Include="Interfaces\ISegmentSupervisor.cs" />
     <Compile Include="Service\Events\ConfirmationLevelChangedEventHandler.cs" />
     <Compile Include="Service\Events\TranslationReceivedEventHandler.cs" />
+    <Compile Include="Service\HttpClient.cs" />
+    <Compile Include="Service\Interface\IHttpClient.cs" />
     <Compile Include="Service\SegmentSupervisor.cs" />
     <Compile Include="Service\ShortcutService.cs" />
     <Compile Include="Service\TranslationService.cs" />

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/HttpClient.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/HttpClient.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Sdl.Community.MTCloud.Provider.Service.Interface;
+
+namespace Sdl.Community.MTCloud.Provider.Service
+{
+	public class HttpClient : IHttpClient
+	{
+		private readonly System.Net.Http.HttpClient _httpClient;
+
+		public HttpClient()
+		{
+			_httpClient = new System.Net.Http.HttpClient();
+		}
+
+		public HttpRequestHeaders DefaultRequestHeaders { get => _httpClient.DefaultRequestHeaders; }
+
+		public TimeSpan Timeout
+		{
+			get => _httpClient.Timeout;
+			set => _httpClient.Timeout = value;
+		}
+
+		public Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage)
+		{
+			return _httpClient.SendAsync(httpRequestMessage);
+		}
+
+		public Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, HttpCompletionOption httpCompletionOption)
+		{
+			return _httpClient.SendAsync(httpRequestMessage, httpCompletionOption);
+		}
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/IHttpClient.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/IHttpClient.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Sdl.Community.MTCloud.Provider.Service.Interface
+{
+	public interface IHttpClient
+	{
+		HttpRequestHeaders DefaultRequestHeaders { get; }
+
+		TimeSpan Timeout { get; set; }
+
+		Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage);
+
+		Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, HttpCompletionOption httpCompletionOption);
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
@@ -119,7 +119,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 		/// corresponding mask)</param>
 		/// <param name="mask">Whether to translate a segment or not</param>
 		/// <returns></returns>
-		public SearchResults[] SearchSegments(SearchSettings settings, Segment[] segments, bool[] mask)
+		public SearchResults[] SearchSegments(Segment[] segments, bool[] mask)
 		{
 			var results = new SearchResults[segments.Length];
 			var mtCloudSegments = new List<MTCloudSegment>();
@@ -311,7 +311,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			// Need this vs having mask parameter default to null as inheritence doesn't allow default values to
 			// count as the same thing as having no parameter at all. IE, you can't have
 			// public string foo(string s = null) override public string foo().
-			return SearchSegments(settings, segments, null);
+			return SearchSegments(segments, null);
 		}
 
 		public SearchResults[] SearchSegmentsMasked(SearchSettings settings, Segment[] segments, bool[] mask)
@@ -381,7 +381,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			_translationUnits.Clear();
 			_translationUnits.AddRange(translationUnits);
 
-			return SearchSegments(settings, translationUnits.Select(tu => tu?.SourceSegment).ToArray(), mask);
+			return SearchSegments(translationUnits.Select(tu => tu?.SourceSegment).ToArray(), mask);
 		}
 
 		public ImportResult AddTranslationUnit(TranslationUnit translationUnit, ImportSettings settings)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
@@ -36,7 +36,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			try
 			{
 				var uri = new Uri($"{Constants.MTCloudUriScheme}://");				
-				var connectionService = new ConnectionService(owner, new VersionService(), StudioInstance.GetLanguageCloudIdentityApi());
+				var connectionService = new ConnectionService(owner, new VersionService(), StudioInstance.GetLanguageCloudIdentityApi(), MTCloudApplicationInitializer.Client);
 				
 				var credential = connectionService.GetCredential(credentialStore);								
 				var connectionResult = connectionService.EnsureSignedIn(credential, true);
@@ -48,13 +48,13 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 				
 				connectionService.SaveCredential(credentialStore);
 
-
 				var editorController = StudioInstance.GetEditorController();
-				var translationService = new TranslationService(connectionService);
+				var translationService = new TranslationService(connectionService, MTCloudApplicationInitializer.Client);
 				var languageProvider = new LanguageProvider();
 				var projectsController = StudioInstance.GetProjectsController();
 
-				var provider = new SdlMTCloudTranslationProvider(uri, string.Empty, translationService, languageProvider, editorController, projectsController);				
+				var provider = new SdlMTCloudTranslationProvider(uri, string.Empty, translationService, languageProvider,
+					editorController, projectsController, true);			
 								
 				return new ITranslationProvider[] { provider };
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProviderFactory.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProviderFactory.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Net.Http;
 using Sdl.Community.MTCloud.Languages.Provider;
 using Sdl.Community.MTCloud.Provider.Service;
+using Sdl.Community.MTCloud.Provider.Service.Interface;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
+using HttpClient = Sdl.Community.MTCloud.Provider.Service.HttpClient;
 
 namespace Sdl.Community.MTCloud.Provider.Studio
 {
@@ -14,7 +17,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			ITranslationProviderCredentialStore credentialStore)
 		{
 			var connectionService = new ConnectionService(StudioInstance.GetActiveForm(), new VersionService(),
-				StudioInstance.GetLanguageCloudIdentityApi());
+				StudioInstance.GetLanguageCloudIdentityApi(), MTCloudApplicationInitializer.Client);
 
 			var credential = connectionService.GetCredential(credentialStore);
 			var connectionResult = connectionService.EnsureSignedIn(credential);
@@ -26,7 +29,8 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			connectionService.SaveCredential(credentialStore);
 
 			var editorController = StudioInstance.GetEditorController();
-			var translationService = new TranslationService(connectionService);
+
+			var translationService = new TranslationService(connectionService, MTCloudApplicationInitializer.Client);
 			var languageProvider = new LanguageProvider();
 			var projectsController = StudioInstance.GetProjectsController();
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
@@ -283,7 +283,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			var comments = isFeedbackForPreviousSegment ? PreviousRating.Comments : GetCommentsAndFeedbackFromUi();
 			if (comments?.Count > 0) rating.Comments = comments;
 
-			PreviousRating = null;
+			PreviousRating.Empty();
 
 			if (!((ExpandoObject)rating).Any()) rating = null;
 			return rating;

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>SDL Machine Translation Cloud</PlugInName>
-	<Version>3.2.2.0</Version>
+	<Version>3.2.3.0</Version>
 	<Description>SDL Machine Translation Cloud provider</Description>
 	<Author>SDL Community Developers</Author>
 	<Include>


### PR DESCRIPTION
 - small refactorings and an "Object reference not set to an instance of an object" bug fixed
 - use only one instance of httpClient throughout the entire lifecycle of the app
 - fixed issue which made Rate It window to always pop up when starting editor even if it was closed in the previous session