### PR TITLE
SDL MT Cloud: Switching projects issue

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Events/ActiveSegmentQeChanged.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Events/ActiveSegmentQeChanged.cs
@@ -2,6 +2,6 @@
 {
 	public class ActiveSegmentQeChanged
 	{
-		public string Estimation{ get; set; }
+		public string Estimation { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Events/ActiveSegmentQeChanged.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Events/ActiveSegmentQeChanged.cs
@@ -1,0 +1,7 @@
+﻿namespace Sdl.Community.MTCloud.Provider.Events
+{
+	public class ActiveSegmentQeChanged
+	{
+		public string Estimation{ get; set; }
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/FileAndSegmentIds.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/FileAndSegmentIds.cs
@@ -6,6 +6,6 @@ namespace Sdl.Community.MTCloud.Provider.Model
 	public class FileAndSegmentIds
 	{
 		public string FilePath;
-		public List<SegmentId> SegmentIds;
+		public Dictionary<SegmentId, string> Segments;
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Options.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Options.cs
@@ -7,6 +7,11 @@ namespace Sdl.Community.MTCloud.Provider.Model
 	{
 		private bool _sendFeedback;
 
+		public Options()
+		{
+			LanguageMappings = new List<LanguageMappingModel>();
+		}
+
 		public bool AutoSendFeedback { get; set; }
 		public List<LanguageMappingModel> LanguageMappings { get; set; } = new();
 		public bool ResendDraft { get; set; }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Options.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/Options.cs
@@ -5,7 +5,7 @@ namespace Sdl.Community.MTCloud.Provider.Model
 {
 	public class Options : BaseModel
 	{
-		private bool sendFeedback;
+		private bool _sendFeedback;
 
 		public bool AutoSendFeedback { get; set; }
 		public List<LanguageMappingModel> LanguageMappings { get; set; } = new();
@@ -13,10 +13,10 @@ namespace Sdl.Community.MTCloud.Provider.Model
 
 		public bool SendFeedback
 		{
-			get => sendFeedback;
+			get => _sendFeedback;
 			set
 			{
-				sendFeedback = value;
+				_sendFeedback = value;
 				OnPropertyChanged(nameof(SendFeedback));
 			}
 		}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/QualityEstimation.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/QualityEstimation.cs
@@ -25,7 +25,7 @@ namespace Sdl.Community.MTCloud.Provider.Model
 			set
 			{
 				_originalEstimation = value;
-				Index = _originalEstimation is not null ? Qualifiers[_originalEstimation] : null;
+				Index = !string.IsNullOrEmpty(_originalEstimation) ? Qualifiers[_originalEstimation] : null;
 				OnPropertyChanged(nameof(OriginalEstimation));
 			}
 		}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationData.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationData.cs
@@ -6,7 +6,7 @@ namespace Sdl.Community.MTCloud.Provider.Model
 	public class TranslationData
 	{
 		public string FilePath { get; set; }
-		public List<SegmentId> SegmentIds { get; set; }
+		public Dictionary<SegmentId, string> Segments { get; set; }
 		public List<string> SourceSegments { get; set; }
 		public string TargetLanguage { get; set; }
 		public List<string> TargetSegments { get; set; }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
@@ -170,6 +170,7 @@
       <DependentUpon>ToolWindowsControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Converters\InvertableBoolEnabledConverter.cs" />
+    <Compile Include="Events\ActiveSegmentQeChanged.cs" />
     <Compile Include="Events\RefreshQeStatus.cs" />
     <Compile Include="Events\VoidEventHandler.cs" />
     <Compile Include="Extensions\WindowsControlUtils.cs" />

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/ISupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/ISupervisor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Sdl.Community.MTCloud.Provider.Interfaces;
 using Sdl.FileTypeSupport.Framework.NativeApi;
@@ -7,8 +8,8 @@ namespace Sdl.Community.MTCloud.Provider.Service.Interface
 {
 	public interface ISupervisor<T>
 	{
-		Dictionary<SegmentId, T> ActiveDocumentData { get; }
-		Dictionary<Guid, Dictionary<SegmentId, T>> Data { get; set; }
+		ConcurrentDictionary<SegmentId, T> ActiveDocumentData { get; }
+		Dictionary<Guid, ConcurrentDictionary<SegmentId, T>> Data { get; set; }
 
 		void StartSupervising(ITranslationService translationService);
 	}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
@@ -37,7 +37,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private IStudioDocument ActiveDocument => _editorController?.ActiveDocument;
 
-		public Dictionary<SegmentId, TranslationOriginInformation> ActiveDocumentData
+		public ConcurrentDictionary<SegmentId, TranslationOriginInformation> ActiveDocumentData
 		{
 			get
 			{
@@ -48,7 +48,6 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			}
 		}
 
-		public Dictionary<Guid, Dictionary<SegmentId, TranslationOriginInformation>> Data { get; set; } = new();
 
 		public string Estimation
 		{
@@ -59,6 +58,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 				ActiveSegmentQeChanged?.Invoke();
 			}
 		}
+		public Dictionary<Guid, ConcurrentDictionary<SegmentId, TranslationOriginInformation>> Data { get; set; } = new();
 
 		public void CloseOpenedDocuments()
 		{
@@ -204,7 +204,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			_docId = ActiveDocument.ActiveFile.Id;
 			if (!Data.ContainsKey(_docId))
 			{
-				Data[_docId] = new Dictionary<SegmentId, TranslationOriginInformation>();
+				Data[_docId] = new ConcurrentDictionary<SegmentId, TranslationOriginInformation>();
 			}
 		}
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
@@ -152,7 +152,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private void EditorController_ActiveDocumentChanged(object sender, DocumentEventArgs e)
 		{
-			if (ActiveDocument == null) return;
+			if (ActiveDocument?.ActiveFile == null) return;
 			SetIdAndActiveFile();
 			ActiveDocument.SegmentsConfirmationLevelChanged -= ActiveDocument_SegmentsConfirmationLevelChanged;
 			ActiveDocument.SegmentsConfirmationLevelChanged += ActiveDocument_SegmentsConfirmationLevelChanged;

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
@@ -180,11 +180,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private string GetCurrentSegmentStoredQe()
 		{
-			var activeSegmentPair = ActiveDocument?.ActiveSegmentPair;
-			if (activeSegmentPair is null) return null;
-
-			ActiveDocumentData.TryGetValue(activeSegmentPair.Properties.Id, out var targetSegmentData);
-			return targetSegmentData?.QualityEstimation;
+			return ActiveDocument?.ActiveSegmentPair?.Properties.TranslationOrigin.GetMetaData("quality_estimation");
 		}
 
 		private void SetBatchProcessingWindow()

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
@@ -181,7 +181,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		{
 			var isActiveSegmentTranslated = !string.IsNullOrWhiteSpace(ActiveDocument?.ActiveSegmentPair?.Target.ToString());
 			var estimation = isActiveSegmentTranslated ? qualityEstimation : null;
-			MtCloudApplicationInitializer.PublishEvent(new ActiveSegmentQeChanged {Estimation = estimation});
+			MtCloudApplicationInitializer.PublishEvent(new ActiveSegmentQeChanged { Estimation = estimation });
 		}
 
 		private void SetIdAndActiveFile()

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetadataSupervisor.cs
@@ -222,10 +222,11 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			}
 			else if (ActiveDocument is not null)
 			{
-				foreach (var sourceSegment in translationData.SourceSegments)
+				foreach (var sourceSegment in translationData.Segments)
 				{
 					var currentSegmentPair =
-						ActiveDocument.SegmentPairs.FirstOrDefault(segPair => segPair.Source.ToString() == sourceSegment);
+						ActiveDocument.SegmentPairs.FirstOrDefault(
+							segPair => segPair.Source.ToString() == sourceSegment.Value || segPair.Properties.Id == sourceSegment.Key);
 
 					AddTargetSegmentMetaData(translationData.TranslationOriginInformation, currentSegmentPair);
 				}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentMetadataCreator.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentMetadataCreator.cs
@@ -62,7 +62,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		private MetadataTransferObject ConvertToSdlMtData(TranslationData translationData) => new()
 		{
 			FilePath = GetFilePath(translationData),
-			SegmentIds = translationData.SegmentIds,
+			SegmentIds = translationData.Segments.Keys.ToList(),
 			TranslationOriginInformation = translationData.TranslationOriginInformation
 		};
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentSupervisor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sdl.Community.MTCloud.Provider.Events;
@@ -27,7 +28,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private IStudioDocument ActiveDocument => _editorController?.ActiveDocument;
 
-		public Dictionary<SegmentId, ImprovementFeedback> ActiveDocumentData
+		public ConcurrentDictionary<SegmentId, ImprovementFeedback> ActiveDocumentData
 		{
 			get
 			{
@@ -38,7 +39,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			}
 		}
 
-		public Dictionary<Guid, Dictionary<SegmentId, ImprovementFeedback>> Data { get; set; } = new();
+		public Dictionary<Guid, ConcurrentDictionary<SegmentId, ImprovementFeedback>> Data { get; set; } = new();
 
 		public void AddImprovement(SegmentId segmentId, string improvement)
 		{
@@ -160,7 +161,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			_docId = ActiveDocument.ActiveFile.Id;
 			if (!Data.ContainsKey(_docId))
 			{
-				Data[_docId] = new Dictionary<SegmentId, ImprovementFeedback>();
+				Data[_docId] = new ConcurrentDictionary<SegmentId, ImprovementFeedback>();
 			}
 		}
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
@@ -153,7 +153,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			var translatedXliff = Converter.ParseXliffString(translation);
 			if (translatedXliff == null) return null;
 
-			var targetSegments = translatedXliff.GetTargetSegments(out var sourceSegments);
+			var targetSegments = translatedXliff.GetTargetSegments();
 
 			OnTranslationReceived(new TranslationData
 			{

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
@@ -157,7 +157,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 			OnTranslationReceived(new TranslationData
 			{
-				SourceSegments = sourceSegments,
+				SourceSegments = fileAndSegments.Segments.Values.ToList(),
 				TargetSegments = targetSegments.Select(seg => seg.ToString()).ToList(),
 				TranslationOriginInformation = new TranslationOriginInformation
 				{
@@ -165,7 +165,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 					QualityEstimation = qualityEstimation
 				},
 				FilePath = fileAndSegments.FilePath,
-				SegmentIds = fileAndSegments.SegmentIds,
+				Segments = fileAndSegments.Segments,
 				TargetLanguage = model.TargetTradosCode
 			});
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
@@ -270,7 +270,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			{
 				FilePath = GetSdlXliffFilePath(translationUnits[0].FileProperties) ??
 						   Path.GetFileName(translationUnits[0]?.FileProperties.FileConversionProperties.OriginalFilePath),
-				SegmentIds = translationUnits.Select(tu => tu.DocumentSegmentPair.Properties.Id).ToList(),
+				Segments = translationUnits.ToDictionary(tu => tu.DocumentSegmentPair.Properties.Id, tu=>tu.SourceSegment.ToString())
 			};
 
 			if (translationUnits == null)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
@@ -270,7 +270,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			{
 				FilePath = GetSdlXliffFilePath(translationUnits[0].FileProperties) ??
 						   Path.GetFileName(translationUnits[0]?.FileProperties.FileConversionProperties.OriginalFilePath),
-				Segments = translationUnits.ToDictionary(tu => tu.DocumentSegmentPair.Properties.Id, tu=>tu.SourceSegment.ToString())
+				Segments = translationUnits.ToDictionary(tu => tu.DocumentSegmentPair.Properties.Id, tu => tu.SourceSegment.ToString())
 			};
 
 			if (translationUnits == null)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
@@ -55,7 +55,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 				var languageProvider = new LanguageProvider();
 				var provider = new SdlMTCloudTranslationProvider(uri, string.Empty, MtCloudApplicationInitializer.TranslationService,
 					languageProvider,
-					editorController, true);
+					editorController);
 
 				return new ITranslationProvider[] { provider };
 			}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudProviderWinFormsUI.cs
@@ -7,10 +7,8 @@ using Sdl.Community.MTCloud.Provider.Events;
 using Sdl.Community.MTCloud.Provider.Service;
 using Sdl.Community.MTCloud.Provider.View;
 using Sdl.Community.MTCloud.Provider.ViewModel;
-using Sdl.Desktop.IntegrationApi.Interfaces;
 using Sdl.LanguagePlatform.Core;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
-using Sdl.TranslationStudioAutomation.IntegrationApi;
 using IWin32Window = System.Windows.Forms.IWin32Window;
 using LogManager = NLog.LogManager;
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -1,21 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using Newtonsoft.Json;
 using NLog;
 using Sdl.Community.MTCloud.Languages.Provider.Interfaces;
 using Sdl.Community.MTCloud.Languages.Provider.Model;
-using Sdl.Community.MTCloud.Provider.Helpers;
 using Sdl.Community.MTCloud.Provider.Interfaces;
 using Sdl.Community.MTCloud.Provider.Model;
 using Sdl.Community.MTCloud.Provider.Service;
-using Sdl.Desktop.IntegrationApi;
 using Sdl.LanguagePlatform.Core;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
 using Sdl.ProjectAutomation.Core;
-using Sdl.ProjectAutomation.FileBased;
 using Sdl.ProjectAutomation.Settings.Events;
 using Sdl.TranslationStudioAutomation.IntegrationApi;
 using LogManager = NLog.LogManager;
@@ -26,10 +22,10 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 	{
 		private readonly EditorController _editorController;
 		private readonly Logger _logger = LogManager.GetCurrentClassLogger();
-		private LanguagePair _languageDirection;
-		private LanguageMappingsService _languageMappingsService;
 		private readonly RateItController _rateItController;
 		private ProjectInfo _currentProject;
+		private LanguagePair _languageDirection;
+		private LanguageMappingsService _languageMappingsService;
 
 		public SdlMTCloudTranslationProvider(Uri uri, string translationProviderState, ITranslationService translationService,
 		 ILanguageProvider languageProvider, EditorController editorController)
@@ -51,30 +47,6 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			MtCloudApplicationInitializer.Subscribe<TranslationProviderStatusChanged>(Settings_TranslationProviderStatusChanged);
 		}
 
-		private void ProjectsController_CurrentProjectChanged(object sender, EventArgs e)
-		{
-			if (sender is not ProjectsController projController) return;
-			var newProject = projController.CurrentProject.GetProjectInfo();
-			if (newProject == _currentProject) return;
-			_currentProject = newProject;
-
-			var tpState =
-				projController.CurrentProject.GetTranslationProviderConfiguration().Entries.FirstOrDefault(
-					entry => entry.MainTranslationProvider.Uri.ToString().Contains("sdlmtcloud"))?.MainTranslationProvider.State;
-
-			var currentLanguagePair = new LanguagePair(_currentProject.SourceLanguage.CultureInfo,
-				_editorController?.ActiveDocument?.ActiveFile.Language.CultureInfo);
-
-			if (_editorController is null) return;
-
-			LoadState(tpState);
-			if (tpState != null && currentLanguagePair.TargetCulture != null)
-			{
-				GetMTCloudLanguagePair(currentLanguagePair);
-			}
-			ActivateRatingController();
-		}
-
 		public bool IsReadOnly => true;
 
 		public ITranslationProviderLanguageDirection LanguageDirectionProvider { get; private set; }
@@ -94,7 +66,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 				if (TranslationService.Options != null)
 				{
 					TranslationService.Options.PropertyChanged +=
-						(s, e) => { SwitchRateTranslationsControllerVisibility(((Options) s).SendFeedback); };
+						(s, e) => { SwitchRateTranslationsControllerVisibility(((Options)s).SendFeedback); };
 				}
 			}
 		}
@@ -388,6 +360,30 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 		{
 			return engineModels.Count == 1 &&
 				   engineModels[0].DisplayName == PluginResources.Message_No_model_available;
+		}
+
+		private void ProjectsController_CurrentProjectChanged(object sender, EventArgs e)
+		{
+			if (sender is not ProjectsController projController) return;
+			var newProject = projController.CurrentProject.GetProjectInfo();
+			if (newProject == _currentProject) return;
+			_currentProject = newProject;
+
+			var tpState =
+				projController.CurrentProject.GetTranslationProviderConfiguration().Entries.FirstOrDefault(
+					entry => entry.MainTranslationProvider.Uri.ToString().Contains("sdlmtcloud"))?.MainTranslationProvider.State;
+
+			var currentLanguagePair = new LanguagePair(_currentProject.SourceLanguage.CultureInfo,
+				_editorController?.ActiveDocument?.ActiveFile.Language.CultureInfo);
+
+			if (_editorController is null) return;
+
+			LoadState(tpState);
+			if (tpState != null && currentLanguagePair.TargetCulture != null)
+			{
+				GetMTCloudLanguagePair(currentLanguagePair);
+			}
+			ActivateRatingController();
 		}
 
 		private void Settings_TranslationProviderStatusChanged(TranslationProviderStatusChanged tpInfo)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -63,7 +63,12 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			var currentLanguagePair = new LanguagePair(_currentProject.SourceLanguage.CultureInfo,
 				_editorController?.ActiveDocument?.ActiveFile.Language.CultureInfo);
 
+			if (_editorController is null) return;
+
+			if (tpState != null)
+			{
 				GetMTCloudLanguagePair(currentLanguagePair);
+			}
 			LoadState(tpState);
             ActivateRatingController();
 		}
@@ -197,23 +202,22 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 		{
 			try
 			{
-				Options = JsonConvert.DeserializeObject<Options>(translationProviderState) ?? new Options
-				{
-					AutoSendFeedback = true,
-					LanguageMappings = new List<LanguageMappingModel>(),
-					ResendDraft = true,
-					SendFeedback = true
-				};
+				Options = JsonConvert.DeserializeObject<Options>(translationProviderState);
 			}
 			catch
 			{
 				// ignore any casting errors and simply create a new options instance
-				Options = new Options();
 			}
-			finally
-			{
-				ActivateRatingController();
-			}
+
+			Options = translationProviderState is not null
+				? Options ?? new Options
+				{
+					AutoSendFeedback = true,
+					LanguageMappings = new List<LanguageMappingModel>(),
+					ResendDraft = true,
+					SendFeedback = true,
+				}
+				: new Options();
 		}
 
 		public void RefreshStatusInfo()

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -266,7 +266,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			if (!MtCloudApplicationInitializer.IsStudioRunning()) return;
 
 			var tpStatus = GetTpStatus();
-			if (!(tpStatus ?? false)) return;
+			if (tpStatus is null) return;
 
 			try
 			{

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -380,8 +380,8 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 
 		private bool HasOptionsLanguageMapping(LanguagePair languagePair)
 		{
-			return Options.LanguageMappings.Any(l => l.SourceTradosCode.Equals(languagePair.SourceCulture.Name)
-													&& l.TargetTradosCode.Equals(languagePair.TargetCulture.Name));
+			return Options?.LanguageMappings?.Any(l => l.SourceTradosCode.Equals(languagePair.SourceCulture.Name)
+													&& l.TargetTradosCode.Equals(languagePair.TargetCulture.Name)) ?? false;
 		}
 
 		private bool NoEngineFound(IReadOnlyList<TranslationModel> engineModels)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -67,7 +67,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 
 			if (_editorController is null) return;
 
-			if (tpState != null)
+			if (tpState != null && currentLanguagePair.TargetCulture != null)
 			{
 				GetMTCloudLanguagePair(currentLanguagePair);
 			}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -26,6 +26,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 		private LanguagePair _languageDirection;
 		private LanguageMappingsService _languageMappingsService;
 		private RateItController _rateItController;
+		private ProjectInfo _currentProject;
 
 		public SdlMTCloudTranslationProvider(Uri uri, string translationProviderState, ITranslationService translationService,
 		 ILanguageProvider languageProvider, EditorController editorController, bool firstTimeAdded = false)
@@ -35,10 +36,36 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			TranslationService = translationService;
 			_editorController = editorController;
 			_firstTimeAdded = firstTimeAdded;
+			_rateItController = SdlTradosStudio.Application.GetController<RateItController>();
+
+			var projectsController = MtCloudApplicationInitializer.ProjectsController;
+			projectsController.CurrentProjectChanged -= ProjectsController_CurrentProjectChanged;
+			projectsController.CurrentProjectChanged += ProjectsController_CurrentProjectChanged;
+			_currentProject = projectsController.CurrentProject.GetProjectInfo();
 
 			LoadState(translationProviderState);
+			ActivateRatingController();
 
 			MtCloudApplicationInitializer.Subscribe<TranslationProviderStatusChanged>(Settings_TranslationProviderStatusChanged);
+		}
+
+		private void ProjectsController_CurrentProjectChanged(object sender, EventArgs e)
+		{
+			if (sender is not ProjectsController projController) return;
+			var newProject = projController.CurrentProject.GetProjectInfo();
+			if (newProject == _currentProject) return;
+			_currentProject = newProject;
+
+			var tpState =
+				projController.CurrentProject.GetTranslationProviderConfiguration().Entries.FirstOrDefault(
+					entry => entry.MainTranslationProvider.Uri.ToString().Contains("sdlmtcloud"))?.MainTranslationProvider.State;
+
+			var currentLanguagePair = new LanguagePair(_currentProject.SourceLanguage.CultureInfo,
+				_editorController?.ActiveDocument?.ActiveFile.Language.CultureInfo);
+
+				GetMTCloudLanguagePair(currentLanguagePair);
+			LoadState(tpState);
+            ActivateRatingController();
 		}
 
 		public bool IsReadOnly => true;

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -67,12 +67,12 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 
 			if (_editorController is null) return;
 
+			LoadState(tpState);
 			if (tpState != null && currentLanguagePair.TargetCulture != null)
 			{
 				GetMTCloudLanguagePair(currentLanguagePair);
 			}
-			LoadState(tpState);
-            ActivateRatingController();
+			ActivateRatingController();
 		}
 
 		public bool IsReadOnly => true;
@@ -91,10 +91,11 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			set
 			{
 				TranslationService.Options = value;
-				TranslationService.Options.PropertyChanged += (s, e) =>
+				if (TranslationService.Options != null)
 				{
-					SwitchRateTranslationsControllerVisibility(((Options)s).SendFeedback);
-				};
+					TranslationService.Options.PropertyChanged +=
+						(s, e) => { SwitchRateTranslationsControllerVisibility(((Options) s).SendFeedback); };
+				}
 			}
 		}
 
@@ -202,6 +203,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 
 		public void LoadState(string translationProviderState)
 		{
+			if (translationProviderState is null) Options = new Options();
 			try
 			{
 				Options = JsonConvert.DeserializeObject<Options>(translationProviderState);
@@ -211,15 +213,13 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 				// ignore any casting errors and simply create a new options instance
 			}
 
-			Options = translationProviderState is not null
-				? Options ?? new Options
-				{
-					AutoSendFeedback = true,
-					LanguageMappings = new List<LanguageMappingModel>(),
-					ResendDraft = true,
-					SendFeedback = true,
-				}
-				: new Options();
+			Options ??= new Options
+			{
+				AutoSendFeedback = true,
+				LanguageMappings = new List<LanguageMappingModel>(),
+				ResendDraft = true,
+				SendFeedback = true,
+			};
 		}
 
 		public void RefreshStatusInfo()

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudTranslationProvider.cs
@@ -188,7 +188,6 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 			Options ??= new Options
 			{
 				AutoSendFeedback = true,
-				LanguageMappings = new List<LanguageMappingModel>(),
 				ResendDraft = true,
 				SendFeedback = true,
 			};
@@ -374,7 +373,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 					entry => entry.MainTranslationProvider.Uri.ToString().Contains("sdlmtcloud"))?.MainTranslationProvider.State;
 
 			var currentLanguagePair = new LanguagePair(_currentProject.SourceLanguage.CultureInfo,
-				_editorController?.ActiveDocument?.ActiveFile.Language.CultureInfo);
+				_editorController?.ActiveDocument?.ActiveFile?.Language.CultureInfo);
 
 			if (_editorController is null) return;
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
@@ -335,9 +335,9 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			return isResetNeeded;
 		}
 
-		private void MetadataSupervisor_ActiveSegmentQeChanged()
+		private void MetadataSupervisor_ActiveSegmentQeChanged(ActiveSegmentQeChanged data)
 		{
-			Evaluation.OriginalEstimation = MtCloudApplicationInitializer.MetadataSupervisor.Estimation;
+			Evaluation.OriginalEstimation = data.Estimation;
 		}
 
 		private async void OnConfirmationLevelChanged(SegmentId confirmedSegment)
@@ -498,13 +498,11 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 			if (_translationService?.IsActiveModelQeEnabled ?? false)
 			{
 				QeEnabled = true;
-				MtCloudApplicationInitializer.MetadataSupervisor.ActiveSegmentQeChanged -= MetadataSupervisor_ActiveSegmentQeChanged;
-				MtCloudApplicationInitializer.MetadataSupervisor.ActiveSegmentQeChanged += MetadataSupervisor_ActiveSegmentQeChanged;
+				MtCloudApplicationInitializer.Subscribe<ActiveSegmentQeChanged>(MetadataSupervisor_ActiveSegmentQeChanged);
 			}
 			else
 			{
 				QeEnabled = false;
-				MtCloudApplicationInitializer.MetadataSupervisor.ActiveSegmentQeChanged -= MetadataSupervisor_ActiveSegmentQeChanged;
 			}
 		}
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
@@ -10,9 +10,7 @@ using Sdl.Community.MTCloud.Provider.Commands;
 using Sdl.Community.MTCloud.Provider.Events;
 using Sdl.Community.MTCloud.Provider.Interfaces;
 using Sdl.Community.MTCloud.Provider.Model;
-using Sdl.Desktop.IntegrationApi.Interfaces;
 using Sdl.FileTypeSupport.Framework.NativeApi;
-using Sdl.ProjectAutomation.Settings;
 using Sdl.TranslationStudioAutomation.IntegrationApi;
 
 namespace Sdl.Community.MTCloud.Provider.ViewModel
@@ -434,7 +432,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 
 			var feedbackInfo = new FeedbackInfo
 			{
-				Evaluation = Evaluation.OriginalEstimation != null? Evaluation : null,
+				Evaluation = Evaluation.OriginalEstimation != null ? Evaluation : null,
 				Rating = rating,
 				SegmentId = segmentId,
 				Suggestion = suggestionReplacement ?? suggestion?.Improvement,

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/ViewModel/RateItViewModel.cs
@@ -434,7 +434,7 @@ namespace Sdl.Community.MTCloud.Provider.ViewModel
 
 			var feedbackInfo = new FeedbackInfo
 			{
-				Evaluation = Evaluation,
+				Evaluation = Evaluation.OriginalEstimation != null? Evaluation : null,
 				Rating = rating,
 				SegmentId = segmentId,
 				Suggestion = suggestionReplacement ?? suggestion?.Improvement,

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Converter/Xliff.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Converter/Xliff.cs
@@ -46,9 +46,8 @@ namespace Sdl.Community.MTCloud.Provider.XliffConverter.Converter
 			File?.Body?.Add(sourceSegment, targetSegment, toolId);
 		}
 
-		public Segment[] GetTargetSegments(out List<string> sources)
+		public Segment[] GetTargetSegments()
 		{
-			sources = new List<string>();
 			var segments = new List<Segment>();
 			foreach (var tu in File.Body.TranslationUnits)
 			{
@@ -60,7 +59,6 @@ namespace Sdl.Community.MTCloud.Provider.XliffConverter.Converter
 					return null;
 				}
 
-				sources.Add(tu.SourceText);
 				segment.Culture = File.TargetCulture ?? File.SourceCulture;
 				segments.Add(segment);
 			}


### PR DESCRIPTION
Fixes "Some segments had null QE attributes" issue
Fixes "Not possible to send feedback when QE not enabled" issue
Fixes "Not possible to send feedback when QE not enabled" issue
Fixes "when user activated QE for a language, the label from a document already having QE enabled was placed on the current segment" issue
Fixes "Combobox doesn't enable/disable correctly when switching projects"  issue
Fixes "When opening a project with SDL MT Cloud TP set up AND after that, opening a project without it => exception at LoadState since state will be null" issue
Refactorings
  - necessary for making the problem more easy to understand
  - that just simplified adjacent code