### PR TITLE
Implemented support for Microsoft Translator with Private Endpoints

### DIFF
--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/Model/Interface/IMtTranslationOptions.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/Model/Interface/IMtTranslationOptions.cs
@@ -21,6 +21,7 @@ namespace Sdl.Community.MtEnhancedProvider.Model.Interface
 		string JsonFilePath { get; set; }
 		string ProjectName { get; set; }
 		string GlossaryPath { get; set; }
+		string PeUrl { get; set; } // Microsoft private endpont url
 		string ApiKey { get; set; } //Google Key
 		string ClientId { get; set; } // Microsoft key
 		string Region { get; set; } // Microsoft Region

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MstConnect/ApiConnecterWithPe.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MstConnect/ApiConnecterWithPe.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NLog;
+using RestSharp;
+using Sdl.Community.MtEnhancedProvider.Model;
+using Sdl.Community.MtEnhancedProvider.Service;
+
+namespace Sdl.Community.MtEnhancedProvider.MstConnect
+{
+	internal class ApiConnecterWithPe
+	{
+		private const string OcpApimSubscriptionKeyHeader = "Ocp-Apim-Subscription-Key";
+
+		private List<string> _supportedLangs;
+
+		private readonly string _peUrl;
+		private string _subscriptionKey;
+		private string _region;
+		private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+		private HtmlUtil _htmlUtil;
+
+		/// <summary>
+		/// This class allows connection to the Microsoft Translation API
+		/// </summary>
+		/// <param name="subscriptionKey">Microsoft API key</param>
+		/// <param name="region">Region</param>
+		internal ApiConnecterWithPe(string peUrl, string subscriptionKey, string region, HtmlUtil htmlUtil)
+		{
+			_peUrl = peUrl;
+			_subscriptionKey = subscriptionKey;
+			_region = region;
+			_htmlUtil = htmlUtil;
+
+			if (_supportedLangs == null)
+			{
+				_supportedLangs = GetSupportedLanguages(); //if the class variable has not been set
+			}
+		}
+
+		/// <summary>
+		/// translates the text input
+		/// </summary>
+		internal string Translate(string sourceLang, string targetLang, string textToTranslate, string categoryId)
+		{
+			//convert our language codes
+			var sourceLc = ConvertLangCode(sourceLang);
+			var targetLc = ConvertLangCode(targetLang);
+
+			var translatedText = string.Empty;
+			try
+			{
+				//search for words like this <word> 
+				var rgx = new Regex("(\\<\\w+[üäåëöøßşÿÄÅÆĞ]*[^\\d\\W\\\\/\\\\]+\\>)");
+				var words = rgx.Matches(textToTranslate);
+				if (words.Count > 0)
+				{
+					textToTranslate = ReplaceCharacters(textToTranslate, words);
+				}
+
+				const string path = "/translate?api-version=3.0";
+				var category = categoryId == "" ? "general" : categoryId;
+				var languageParams = $"&from={sourceLc}&to={targetLc}&textType=html&category={category}";
+
+				var uri = string.Concat(_peUrl, path, languageParams);
+				var body = new object[]
+				{
+					new
+					{
+						Text =textToTranslate
+					}
+				};
+				var requestBody = JsonConvert.SerializeObject(body);
+				using (var httpClient = new HttpClient())
+				{
+					using (var httpRequest = new HttpRequestMessage())
+					{
+						httpRequest.Method = HttpMethod.Post;
+						httpRequest.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+						httpRequest.RequestUri = new Uri(uri);
+						httpRequest.Headers.Add(OcpApimSubscriptionKeyHeader, _subscriptionKey);
+
+						var response = httpClient.SendAsync(httpRequest).Result;
+						var responseBody = response.Content.ReadAsStringAsync().Result;
+						if (response.IsSuccessStatusCode)
+						{
+							var responseTranslation = JsonConvert.DeserializeObject<List<TranslationResponse>>(responseBody);
+							translatedText = _htmlUtil.HtmlDecode(responseTranslation[0]?.Translations[0]?.Text);
+						}
+						else
+						{
+							var responseMessage = JsonConvert.DeserializeObject<ResponseMessage>(responseBody);
+							throw new Exception(responseMessage.Error.Message);
+						}
+					}
+				}
+			}
+			catch (WebException exception)
+			{
+				var mesg = ProcessWebException(exception, PluginResources.MsApiFailedGetLanguagesMessage);
+				_logger.Error($"{MethodBase.GetCurrentMethod().Name}\n {exception.Message}\n { exception.StackTrace}");
+				throw new Exception(mesg);
+			}
+			return translatedText;
+		}
+
+		private string ReplaceCharacters(string textToTranslate, MatchCollection matches)
+		{
+			var indexes = new List<int>();
+			foreach (Match match in matches)
+			{
+				if (match.Index.Equals(0))
+				{
+					indexes.Add(match.Length);
+				}
+				else
+				{
+					//check if there is any text after PI
+					var remainingText = textToTranslate.Substring(match.Index + match.Length);
+					if (!string.IsNullOrEmpty(remainingText))
+					{
+						//get the position where PI starts to split before
+						indexes.Add(match.Index);
+						//split after PI
+						indexes.Add(match.Index + match.Length);
+					}
+					else
+					{
+						indexes.Add(match.Index);
+					}
+				}
+			}
+			var splitText = textToTranslate.SplitAt(indexes.ToArray()).ToList();
+			var positions = new List<int>();
+			for (var i = 0; i < splitText.Count; i++)
+			{
+				if (!splitText[i].Contains("tg"))
+				{
+					positions.Add(i);
+				}
+			}
+
+			foreach (var position in positions)
+			{
+				var originalString = splitText[position];
+				var start = Regex.Replace(originalString, "<", "&lt;");
+				var finalString = Regex.Replace(start, ">", "&gt;");
+				splitText[position] = finalString;
+			}
+			var finalText = string.Empty;
+			foreach (var text in splitText)
+			{
+				finalText += text;
+			}
+			return finalText;
+		}
+
+		/// <summary>
+		/// Checks of lang pair is supported by MS
+		/// </summary>
+		internal bool IsSupportedLangPair(string sourceLang, string targetLang)
+		{
+			//convert our language codes
+			var source = ConvertLangCode(sourceLang);
+			var target = ConvertLangCode(targetLang);
+
+			var sourceSupported = false;
+			var targetSupported = false;
+
+			//check to see if both the source and target languages are supported
+			foreach (var lang in _supportedLangs)
+			{
+				if (lang.Equals(source)) sourceSupported = true;
+				if (lang.Equals(target)) targetSupported = true;
+			}
+
+			if (sourceSupported && targetSupported) return true; //if both are supported return true
+
+			//otherwise return false
+			return false;
+		}
+
+		private List<string> GetSupportedLanguages()
+		{
+			var languageCodeList = new List<string>();
+			try
+			{
+				var uri = new Uri(_peUrl);
+				var client = new RestClient(uri);
+
+				var request = new RestRequest("languages", Method.Get);
+				request.AddParameter("api-version", "3.0");
+				request.AddParameter("scope", "translation");
+				request.AddHeader(OcpApimSubscriptionKeyHeader, _subscriptionKey);
+
+				var languageResponse = client.ExecuteAsync(request).Result;
+
+				if (!languageResponse.IsSuccessful) throw new Exception("Error on connecting to translator. " + languageResponse.Content);
+
+				var languages = JsonConvert.DeserializeObject<LanguageResponse>(languageResponse.Content);
+				if (languages != null)
+				{
+					foreach (var language in languages.Translation)
+					{
+						languageCodeList.Add(language.Key);
+					}
+				}
+			}
+			catch (WebException exception)
+			{
+				var mesg = ProcessWebException(exception, PluginResources.MsApiFailedGetLanguagesMessage);
+				_logger.Error($"{MethodBase.GetCurrentMethod().Name}\n{exception.Message}\n { exception.StackTrace}");
+				throw new Exception(mesg);
+			}
+			return languageCodeList;
+		}
+
+		private string ProcessWebException(WebException e, string message)
+		{
+			_logger.Error($"{MethodBase.GetCurrentMethod().Name}\n{e.Response}\n {message}");
+
+			// Obtain detailed error information
+			string strResponse;
+			using (var response = (HttpWebResponse)e.Response)
+			{
+				using (var responseStream = response.GetResponseStream())
+				{
+					using (var sr = new StreamReader(responseStream, Encoding.ASCII))
+					{
+						strResponse = sr.ReadToEnd();
+					}
+				}
+			}
+			return $"Http status code={e.Status}, error message={strResponse}";
+		}
+
+		internal void EnsureConnectivity()
+		{
+			var result = Translate("en", "de", "Hello World!", "");
+
+			if (string.IsNullOrEmpty(result))
+			{
+				throw new InvalidOperationException("No Connection could be established");
+			}
+		}
+
+		private string ConvertLangCode(string languageCode)
+		{
+			//takes the language code input and converts it to one that MS Translate can use
+			if (languageCode.Contains("sr-Cyrl")) return "sr-Cyrl";
+			if (languageCode.Contains("sr-Latn")) return "sr-Latn";
+
+			var ci = new CultureInfo(languageCode); //construct a CultureInfo object with the language code
+
+			//deal with chinese..MS Translator has different ones
+			if (new[] { "zh-TW", "zh-HK", "zh-MO", "zh-Hant", "zh-CHT" }.Contains(ci.Name)) return "zh-Hant";
+			if (new[] { "zh-CN", "zh-SG", "zh-Hans-HK", "zh-Hans-MO", "zh-Hans", "zh-CHS" }.Contains(ci.Name)) return "zh-Hans";
+
+			return ci.TwoLetterISOLanguageName;
+
+		}
+	}
+}

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationOptions.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationOptions.cs
@@ -31,7 +31,8 @@ namespace Sdl.Community.MtEnhancedProvider
         private string _apiKey;
         private string _clientid;
         const string MsTranslatorString = "Microsoft Translator"; //these strings should not be localized or changed and are therefore hard-coded as constants
-        const string GTranslateString = "Google Translate"; //these strings should not be localized or changed and are therefore hard-coded as constants
+		const string MsTranslatorWithPeString = "Microsoft Translator with Private Endpoint"; //these strings should not be localized or changed and are therefore hard-coded as constants
+		const string GTranslateString = "Google Translate"; //these strings should not be localized or changed and are therefore hard-coded as constants
 
         //The translation method affects when/if the plugin gets called by Studio
         public static readonly TranslationMethod ProviderTranslationMethod = TranslationMethod.MachineTranslation;
@@ -158,6 +159,7 @@ namespace Sdl.Community.MtEnhancedProvider
         {
             GoogleTranslate = 1,
             MicrosoftTranslator = 2,
+			MicrosoftTranslatorWithPe = 3,
             None = 0
         }
 
@@ -169,7 +171,9 @@ namespace Sdl.Community.MtEnhancedProvider
 			        return GTranslateString; //these strings should not be localized and are therefore hard-coded
 		        case ProviderType.MicrosoftTranslator:
 			        return MsTranslatorString; //these strings should not be localized and are therefore hard-coded
-	        }
+				case ProviderType.MicrosoftTranslatorWithPe:
+					return MsTranslatorWithPeString; //these strings should not be localized and are therefore hard-coded
+			}
 	        return "";
         }
 
@@ -185,7 +189,9 @@ namespace Sdl.Community.MtEnhancedProvider
 			        return ProviderType.GoogleTranslate;
 		        case MsTranslatorString:
 			        return ProviderType.MicrosoftTranslator;
-		        default:
+				case MsTranslatorWithPeString:
+					return ProviderType.MicrosoftTranslatorWithPe;
+				default:
 			        return ProviderType.None;
 	        }
         }
@@ -245,6 +251,13 @@ namespace Sdl.Community.MtEnhancedProvider
 		{
 			get => _apiKey;
 			set => _apiKey = value;
+		}
+
+		// The Microsoft private endpoint url
+		public string PeUrl
+		{
+			get => GetStringParameter("peurl");
+			set => SetStringParameter("peurl", value);
 		}
 
 		[JsonIgnore] 

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProvider.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProvider.cs
@@ -34,6 +34,7 @@ namespace Sdl.Community.MtEnhancedProvider
 		private MtTranslationProviderGTApiConnecter _gtConnect;
 		private GoogleV3Connecter _googleV3Connecter;
 		private ApiConnecter _mstConnect;
+		private ApiConnecterWithPe _mstConnectWithPe;
 		private readonly HtmlUtil _htmlUtil;
 
 		public MtTranslationProvider(IMtTranslationOptions options, RegionsProvider regionProvider, HtmlUtil htmlUtil)
@@ -141,6 +142,16 @@ namespace Sdl.Community.MtEnhancedProvider
 				}
 
 				return _mstConnect.IsSupportedLangPair(languageDirection.SourceCulture.Name, languageDirection.TargetCulture.Name);
+			}
+
+			if (Options.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe)
+			{
+				if (_mstConnectWithPe == null) //construct ApiConnecter if necessary 
+				{
+					_mstConnectWithPe = new ApiConnecterWithPe(Options.PeUrl, Options.ClientId, Options.Region, _htmlUtil);
+				}
+
+				return _mstConnectWithPe.IsSupportedLangPair(languageDirection.SourceCulture.Name, languageDirection.TargetCulture.Name);
 			}
 
 			if (Options.SelectedGoogleVersion == Enums.GoogleApiVersion.V2)

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderFactory.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderFactory.cs
@@ -40,7 +40,7 @@ namespace Sdl.Community.MtEnhancedProvider
 			var htmlUtil = new HtmlUtil();
 
 			//start with MT...check if we are using MT
-			if (loadOptions.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslator)
+			if (loadOptions.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslator || loadOptions.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe)
 			{
 				// The credential is saved with a different URI scheme than that of the plugin!
 				// We will need to make this known and/or provide a workaround in identifying the credentials

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderWinFormsUI.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderWinFormsUI.cs
@@ -130,7 +130,8 @@ namespace Sdl.Community.MtEnhancedProvider
 				}
 				info.SearchResultImage = PluginResources.my_image;
 			}
-			else if (options.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslator)
+			else if (options.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslator
+					|| options.SelectedProvider == MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe)
 			{
 				info.Name = PluginResources.Microsoft_NiceName;
 				info.TooltipText = PluginResources.Microsoft_Tooltip;
@@ -192,6 +193,11 @@ namespace Sdl.Community.MtEnhancedProvider
 						options.PersistGoogleKey);
 					break;
 				case MtTranslationOptions.ProviderType.MicrosoftTranslator:
+					//set mst cred
+					SetCredentialsOnCredentialStore(credentialStore, PluginResources.UriMs, options.ClientId,
+						options.PersistMicrosoftCreds);
+					break;
+				case MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe:
 					//set mst cred
 					SetCredentialsOnCredentialStore(credentialStore, PluginResources.UriMs, options.ClientId,
 						options.PersistMicrosoftCreds);

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/PluginResources.Designer.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/PluginResources.Designer.cs
@@ -479,6 +479,24 @@ namespace Sdl.Community.MtEnhancedProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Microsoft Private Endpoint Url.
+        /// </summary>
+        public static string MicrosoftPeDescription {
+            get {
+                return ResourceManager.GetString("MicrosoftPeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Microsoft Translator with Private Endpoint.
+        /// </summary>
+        public static string MicrosoftWithPe {
+            get {
+                return ResourceManager.GetString("MicrosoftWithPe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authentication error: bad credentials.
         /// </summary>
         public static string MsApiBadCredentialsMessage {
@@ -558,6 +576,15 @@ namespace Sdl.Community.MtEnhancedProvider {
         public static string PersistMicrosoft {
             get {
                 return ResourceManager.GetString("PersistMicrosoft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Private Endpont Url not valid.
+        /// </summary>
+        public static string PeUrlError {
+            get {
+                return ResourceManager.GetString("PeUrlError", resourceCulture);
             }
         }
         

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/PluginResources.resx
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/PluginResources.resx
@@ -405,4 +405,13 @@
   <data name="GoogleApiKeyDescription" xml:space="preserve">
     <value>Please enter your Google Translate API Key</value>
   </data>
+  <data name="MicrosoftWithPe" xml:space="preserve">
+    <value>Microsoft Translator with Private Endpoint</value>
+  </data>
+  <data name="MicrosoftPeDescription" xml:space="preserve">
+    <value>Microsoft Private Endpoint Url</value>
+  </data>
+  <data name="PeUrlError" xml:space="preserve">
+    <value>Private Endpont Url not valid</value>
+  </data>
 </root>

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/Sdl.Community.MtEnhancedProvider.csproj
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/Sdl.Community.MtEnhancedProvider.csproj
@@ -177,7 +177,19 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Compile Update="PluginResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PluginResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="PluginResources.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>PluginResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
   <PropertyGroup>
     <CreatePluginPackage>true</CreatePluginPackage>
     <ProjectGuid>{B008D046-5127-4120-A5BA-41E4E27F35A8}</ProjectGuid>
@@ -197,6 +209,6 @@
   <PropertyGroup>
     <ApplicationIcon>my_icon.ico</ApplicationIcon>
     <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>C:\Code\SDLCOM - Studio 2022\SdlCommunity.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>SdlCommunity.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 </Project>

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/View/ProviderControl.xaml
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/View/ProviderControl.xaml
@@ -37,7 +37,7 @@
 					SelectedItem="{Binding SelectedTranslationOption}"
 					DisplayMemberPath="Name"
 					DockPanel.Dock="Left" 
-					Width="200"/>
+					Width="266"/>
 				<Button Style="{StaticResource TransparentButtonStyle}"
 						Command="{Binding ShowSettingsCommand}">
 					<DockPanel>
@@ -51,11 +51,24 @@
 		<StackPanel Grid.Row="1"
 		            Visibility="{Binding IsMicrosoftSelected, Converter={StaticResource InvertableBooleanToVisibilityConverter}}"
 		            >
+			<StackPanel Visibility="{Binding IsMicrosoftWithPeSelected, Converter={StaticResource InvertableBooleanToVisibilityConverter}}">
+				<TextBlock 
+					Margin="10, 5, 0, 5" 
+					Text="{x:Static mtEnhanced:PluginResources.MicrosoftPeDescription}"/>
+				<TextBox Style="{StaticResource WatermarkTextBox}"
+						 HorizontalAlignment="Left"
+				         uiHelpers:TextBoxWatermarkHelper.WatermarkText="https://mytranslator.cognitiveservices.azure.com/translator/text/v3.0"
+						 uiHelpers:TextBoxWatermarkHelper.ButtonCommandParameter="PeUrl"
+						 uiHelpers:TextBoxWatermarkHelper.ButtonCommand="{Binding ClearCommand}"
+				         Margin="10,0,0,5"
+						 Width="500"
+				         Text="{Binding PeUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+			</StackPanel>
 			<TextBlock Margin="10,10,0,5" Text="{x:Static mtEnhanced:PluginResources.MicrosoftApiDescription}"/>
 			<controls:BindablePasswordBox
 				HorizontalAlignment="Left"
 				Margin="10,0,0,5"
-				Width="400"
+				Width="500"
 				Style="{DynamicResource Sdl.BindablePasswordBox.GenericStyle}" 
 				Password="{Binding ClientId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
 			<CheckBox

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/Interface/IProviderControlViewModel.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/Interface/IProviderControlViewModel.cs
@@ -37,7 +37,9 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel.Interface
 		string CatId { get; set; }
 		
 		string ApiKey { get; set; } //Google
-		
+	
+		string PeUrl { get; set;  } // Microsoft private endpoint url
+
 		string ClientId { get; set; } //Microsoft
 
 		SubscriptionRegion Region { get; set; }

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/ProviderControlViewModel.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/ProviderControlViewModel.cs
@@ -20,6 +20,7 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 		private TranslationOption _selectedTranslationOption;
 		private GoogleApiVersion _selectedGoogleApiVersion;
 		private bool _isMicrosoftSelected;
+		private bool _isMicrosoftWithPeSelected;
 		private bool _useCatId;
 		private bool _isV2Checked;
 		private bool _persistGoogleKey;
@@ -27,6 +28,7 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 		private bool _isTellMeAction;
 		private bool _basicCsvGlossary;
 		private string _catId;
+		private string _peUrl;
 		private string _apiKey;
 		private string _clientId;
 		private SubscriptionRegion _region;
@@ -66,6 +68,11 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 				},
 				new TranslationOption
 				{
+					Name = PluginResources.MicrosoftWithPe,
+					ProviderType = MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe
+				},
+				new TranslationOption
+				{
 					Name = PluginResources.Google,
 					ProviderType = MtTranslationOptions.ProviderType.GoogleTranslate
 				}
@@ -90,6 +97,7 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 
 			if (_options != null)
 			{
+				PeUrl = _options.PeUrl;
 				ClientId = _options.ClientId;
 				PersistMicrosoftKey = _options.PersistMicrosoftCreds;
 				UseCatId = _options.UseCatID;
@@ -137,6 +145,9 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 					break;
 				case "GlossaryPath":
 					GlossaryPath = string.Empty;
+					break;
+				case "PeUrl":
+					PeUrl = string.Empty;
 					break;
 			}
 		}
@@ -217,7 +228,9 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 			set
 			{
 				_selectedTranslationOption = value;
-				IsMicrosoftSelected = value.ProviderType == MtTranslationOptions.ProviderType.MicrosoftTranslator;
+				IsMicrosoftSelected = value.ProviderType == MtTranslationOptions.ProviderType.MicrosoftTranslator 
+										|| value.ProviderType == MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe;
+				IsMicrosoftWithPeSelected = value.ProviderType == MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe;
 				OnPropertyChanged(nameof(SelectedTranslationOption));
 				ClearMessageRaised?.Invoke();
 			}
@@ -243,6 +256,17 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 			}
 		}
 
+		public bool IsMicrosoftWithPeSelected
+		{
+			get => _isMicrosoftWithPeSelected;
+			set
+			{
+				if (_isMicrosoftWithPeSelected == value) return;
+				_isMicrosoftWithPeSelected = value;
+				OnPropertyChanged(nameof(IsMicrosoftWithPeSelected));
+			}
+		}
+
 		public bool IsV2Checked
 		{
 			get => _isV2Checked;
@@ -262,6 +286,18 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 				if (_apiKey == value) return;
 				_apiKey = value.Trim();
 				OnPropertyChanged(nameof(ApiKey));
+				ClearMessageRaised?.Invoke();
+			}
+		}
+
+		public string PeUrl
+		{
+			get => _peUrl;
+			set
+			{
+				if (_peUrl == value) return;
+				_peUrl = value.Trim();
+				OnPropertyChanged(nameof(PeUrl));
 				ClearMessageRaised?.Invoke();
 			}
 		}
@@ -418,12 +454,19 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel
 					{
 						case MtTranslationOptions.ProviderType.GoogleTranslate:
 							IsMicrosoftSelected = false;
+							IsMicrosoftWithPeSelected = false;
 							break;
 						case MtTranslationOptions.ProviderType.MicrosoftTranslator:
 							IsMicrosoftSelected = true;
+							IsMicrosoftWithPeSelected = false;
+							break;
+						case MtTranslationOptions.ProviderType.MicrosoftTranslatorWithPe:
+							IsMicrosoftSelected = true;
+							IsMicrosoftWithPeSelected = true;
 							break;
 						case MtTranslationOptions.ProviderType.None:
 							IsMicrosoftSelected = false;
+							IsMicrosoftWithPeSelected = false;
 							break;
 					}
 					SelectedTranslationOption = selectedProvider;


### PR DESCRIPTION
Hi RWS Team, 

I developed a new feature for the MT Enhanced Provider Plugin which allows to configure the Azure Translation using a private endpoint connected to a company network. Using such a private endpoint the data to translate does not need to be send to Azure via the public internet. 

In case of any questions, don't hesitate to contact me. At continental we would be very happy if you can merge those changes into the next version and also offer the modified plugin via your store. 

Kind Regards, 
Daniel