### PR TITLE
Multilingual Excel FileType 3.0.2.1: DET-686 - projects created with earlier versions not compatible with current

### DIFF
--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/Actions/MigrateLegacyFileTypeIdAction.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/Actions/MigrateLegacyFileTypeIdAction.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using Multilingual.Excel.FileType.Services;
+using Sdl.Desktop.IntegrationApi;
+using Sdl.Desktop.IntegrationApi.Extensions;
+using Sdl.ProjectAutomation.FileBased;
+using Sdl.TranslationStudioAutomation.IntegrationApi;
+using Sdl.TranslationStudioAutomation.IntegrationApi.Presentation.DefaultLocations;
+
+namespace Multilingual.Excel.FileType.Actions
+{
+    /// <summary>
+    /// Ribbon group that hosts Multilingual Excel FileType maintenance actions
+    /// in the Projects view.
+    /// </summary>
+    [RibbonGroup(
+        "Multilingual.Excel.FileType.RibbonGroup",
+        Name = "Multilingual Excel",
+        ContextByType = typeof(ProjectsController))]
+    [RibbonGroupLayout(LocationByType = typeof(TranslationStudioDefaultRibbonTabs.HomeRibbonTabLocation))]
+    public class MultilingualExcelRibbonGroup : AbstractRibbonGroup
+    {
+    }
+
+    /// <summary>
+    /// Explicit, user-triggered migration of legacy versioned file type identifiers
+    /// (e.g. "Multilingual Excel FileType v 3.0.2.0") to the stable, unversioned
+    /// "Multilingual Excel FileType" identifier inside the selected project's
+    /// .sdlproj and .sdlxliff files.
+    /// </summary>
+    [Action(
+        "Multilingual.Excel.FileType.MigrateLegacyFileTypeIdAction",
+        Name = "Migrate Legacy File Type Id",
+        Icon = "MLExcel",
+        Description = "Use this on a project that was created with an earlier version of the Multilingual Excel FileType plugin. It removes the legacy version suffix (e.g. ' v 1.0.0.0') from references to the Multilingual Excel FileType in the selected project's .sdlproj and .sdlxliff files so the project is compatible with the currently installed version of the plugin.")]
+    [ActionLayout(typeof(MultilingualExcelRibbonGroup), 10, DisplayType.Large)]
+    public class MigrateLegacyFileTypeIdAction : AbstractAction
+    {
+        protected override void Execute()
+        {
+            FileBasedProject project = null;
+            try
+            {
+                var projectsController = SdlTradosStudio.Application.GetController<ProjectsController>();
+                if (projectsController == null)
+                {
+                    MessageBox.Show(
+                        "Trados Studio Projects view is not available.",
+                        "Multilingual Excel FileType",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                    return;
+                }
+
+                project = projectsController.SelectedProjects?.FirstOrDefault()
+                          ?? projectsController.CurrentProject;
+
+                if (project == null)
+                {
+                    MessageBox.Show(
+                        "Please select a project in the Projects view first.",
+                        "Multilingual Excel FileType",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                    return;
+                }
+
+                var projectName = project.GetProjectInfo()?.Name ?? "(unknown)";
+                var projectFilePath = project.FilePath;
+
+                var confirm = MessageBox.Show(
+                    "This will remove the legacy version suffix (e.g. ' v 3.0.2.0') from references to the Multilingual Excel FileType inside the .sdlproj and all .sdlxliff files of the selected project:\r\n\r\n"
+                        + projectName
+                        + "\r\n\r\nThe project will be closed in Studio, the files will be rewritten in place (original encoding/BOM preserved, only the exact suffix removed), and the project will then be re-opened.\r\n\r\nProceed?",
+                    "Multilingual Excel FileType",
+                    MessageBoxButtons.OKCancel,
+                    MessageBoxIcon.Question,
+                    MessageBoxDefaultButton.Button2);
+
+                if (confirm != DialogResult.OK)
+                {
+                    return;
+                }
+
+                // Studio keeps the .sdlproj open and re-writes it on close,
+                // which undoes our migration. We must therefore:
+                //   1. Close the project in Studio so it releases its handles
+                //      AND stops tracking pending changes for it.
+                //   2. Rewrite the files on disk.
+                //   3. Re-add the project so the user sees the updated copy.
+                try
+                {
+                    projectsController.Close(project);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning("MultilingualExcel: failed to close project '{0}' before migration: {1}", projectName, ex.Message);
+                }
+
+                var service = new FileTypeIdMigrationService();
+                service.MigrateProject(project);
+
+                FileBasedProject reopened = null;
+                if (!string.IsNullOrEmpty(projectFilePath) && File.Exists(projectFilePath))
+                {
+                    try
+                    {
+                        reopened = projectsController.Add(projectFilePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceWarning("MultilingualExcel: failed to re-add project '{0}' after migration: {1}", projectName, ex.Message);
+                    }
+                }
+
+                MessageBox.Show(
+                    "Migration completed for project:\r\n\r\n"
+                        + projectName
+                        + (reopened == null
+                            ? "\r\n\r\nThe project could not be re-opened automatically; please open it manually from:\r\n" + projectFilePath
+                            : "\r\n\r\nThe project has been re-opened.")
+                        + "\r\n\r\nSee the Trace output for per-file details.",
+                    "Multilingual Excel FileType",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    "Migration failed: " + ex.Message,
+                    "Multilingual Excel FileType",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+        }
+    }
+}

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/ApplicationInstance.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/ApplicationInstance.cs
@@ -1,41 +1,23 @@
 ﻿using System.Windows.Forms;
-using Multilingual.Excel.FileType.FileType.Processors;
-using Multilingual.Excel.FileType.Services.Entities;
-using Multilingual.Excel.FileType.Services;
-using Sdl.Desktop.IntegrationApi;
-using Sdl.Desktop.IntegrationApi.Extensions;
-using Sdl.FileTypeSupport.Framework.Core.Utilities.BilingualApi;
-using Sdl.FileTypeSupport.Framework.Core.Utilities.NativeApi;
-using Sdl.TranslationStudioAutomation.IntegrationApi;
 
 namespace Multilingual.Excel.FileType
 {
-	[ApplicationInitializer]
-	internal class ApplicationInstance : IApplicationInitializer
-	{
-		private EditorController _controller;
+    internal class ApplicationInstance
+    {
+        public static Form GetActiveForm()
+        {
+            var allForms = Application.OpenForms;
+            var activeForm = allForms[allForms.Count - 1];
+            foreach (Form form in allForms)
+            {
+                if (form.GetType().Name == "StudioWindowForm")
+                {
+                    activeForm = form;
+                    break;
+                }
+            }
 
-		public void Execute()
-		{
-		}
-
-		//public EditorController EditorController =>
-		//	_controller ??= SdlTradosStudio.Application.GetController<EditorController>();
-
-		public static Form GetActiveForm()
-		{
-			var allForms = Application.OpenForms;
-			var activeForm = allForms[allForms.Count - 1];
-			foreach (Form form in allForms)
-			{
-				if (form.GetType().Name == "StudioWindowForm")
-				{
-					activeForm = form;
-					break;
-				}
-			}
-
-			return activeForm;
-		}
-	}
+            return activeForm;
+        }
+    }
 }

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/BatchTaskBase.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/BatchTaskBase.cs
@@ -1,0 +1,70 @@
+using Multilingual.Excel.FileType.Constants;
+using Multilingual.Excel.FileType.FileType.Processors;
+using Multilingual.Excel.FileType.Services;
+using Sdl.ProjectAutomation.AutomaticTasks;
+using Sdl.ProjectAutomation.Core;
+using Sdl.ProjectAutomation.FileBased;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Multilingual.Excel.FileType.BatchTasks
+{
+    public abstract class BatchTaskBase : AbstractFileContentProcessingAutomaticTask
+    {
+        protected static void UpdateFile(ProjectFile projectFile, SdlxliffUpdater sdlxliffUpdater)
+        {
+            var updatedFilePath = Path.GetTempFileName();
+            sdlxliffUpdater.UpdateFile(projectFile.LocalFilePath, updatedFilePath);
+            File.Copy(updatedFilePath, projectFile.LocalFilePath, true);
+            if (File.Exists(updatedFilePath))
+            {
+                File.Delete(updatedFilePath);
+            }
+        }
+
+        public override bool ShouldProcessFile(ProjectFile projectFile)
+        {
+            var valid = projectFile.FileTypeId == FiletypeConstants.FileTypeDefinitionId;
+            if (!valid)
+            {
+                var message = string.Format(PluginResources.ExceptionMessage_Incorrect_File_Type,
+                    projectFile.FileTypeId, FiletypeConstants.FileTypeDefinitionId);
+                throw new Exception(message);
+            }
+
+            return true;
+        }
+
+        protected List<Models.AnalysisBand> GetAnalysisBands(FileBasedProject project)
+        {
+            var regex = new Regex(@"(?<min>[\d]*)([^\d]*)(?<max>[\d]*)", RegexOptions.IgnoreCase);
+
+            var analysisBands = new List<Models.AnalysisBand>();
+            var type = project.GetType();
+            var internalProjectField = type.GetField("_project", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (internalProjectField != null)
+            {
+                dynamic internalDynamicProject = internalProjectField.GetValue(project);
+                foreach (var analysisBand in internalDynamicProject.AnalysisBands)
+                {
+                    Match match = regex.Match(analysisBand.ToString());
+                    if (match.Success)
+                    {
+                        var min = match.Groups["min"].Value;
+                        var max = match.Groups["max"].Value;
+                        analysisBands.Add(new Models.AnalysisBand
+                        {
+                            MinimumMatchValue = Convert.ToInt32(min),
+                            MaximumMatchValue = Convert.ToInt32(max)
+                        });
+                    }
+                }
+            }
+
+            return analysisBands;
+        }
+    }
+}

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/ExportBatchTask.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/ExportBatchTask.cs
@@ -32,7 +32,7 @@ namespace Multilingual.Excel.FileType.BatchTasks
 		GeneratedFileType = AutomaticTaskFileType.BilingualTarget, AllowMultiple = true)]
 	[AutomaticTaskSupportedFileType(AutomaticTaskFileType.BilingualTarget)]
 	[RequiresSettings(typeof(MultilingualExcelExportSettings), typeof(ExportSettingsPage))]
-	public class ExportBatchTask : AbstractFileContentProcessingAutomaticTask
+	public class ExportBatchTask : BatchTaskBase
 	{
 		private MultilingualExcelExportSettings _settings;
 		private ExcelReader _excelReader;
@@ -93,30 +93,6 @@ namespace Multilingual.Excel.FileType.BatchTasks
 				var sdlxliffUpdaterUnProtectEmptyTarget = new SdlxliffUpdater(new EmptyTargetProcessor(_segmentBuilder, false));
 				UpdateFile(projectFile, sdlxliffUpdaterUnProtectEmptyTarget);
 			}
-		}
-
-		private static void UpdateFile(ProjectFile projectFile, SdlxliffUpdater sdlxliffUpdater)
-		{
-			var updatedFilePath = Path.GetTempFileName();
-			sdlxliffUpdater.UpdateFile(projectFile.LocalFilePath, updatedFilePath);
-			File.Copy(updatedFilePath, projectFile.LocalFilePath, true);
-			if (File.Exists(updatedFilePath))
-			{
-				File.Delete(updatedFilePath);
-			}
-		}
-
-		public override bool ShouldProcessFile(ProjectFile projectFile)
-		{
-			var valid = projectFile.FileTypeId == FiletypeConstants.FileTypeDefinitionId;
-			if (!valid)
-			{
-				var message = string.Format(PluginResources.ExceptionMessage_Incorrect_File_Type,
-					projectFile.FileTypeId, FiletypeConstants.FileTypeDefinitionId);
-				throw new Exception(message);
-			}
-
-			return true;
 		}
 
 		public override bool OnFileComplete(ProjectFile projectFile, IMultiFileConverter multiFileConverter)
@@ -238,33 +214,5 @@ namespace Multilingual.Excel.FileType.BatchTasks
 			return projectPath;
 		}
 
-		private List<Models.AnalysisBand> GetAnalysisBands(FileBasedProject project)
-		{
-			var regex = new Regex(@"(?<min>[\d]*)([^\d]*)(?<max>[\d]*)", RegexOptions.IgnoreCase);
-
-			var analysisBands = new List<Models.AnalysisBand>();
-			var type = project.GetType();
-			var internalProjectField = type.GetField("_project", BindingFlags.NonPublic | BindingFlags.Instance);
-			if (internalProjectField != null)
-			{
-				dynamic internalDynamicProject = internalProjectField.GetValue(project);
-				foreach (var analysisBand in internalDynamicProject.AnalysisBands)
-				{
-					Match match = regex.Match(analysisBand.ToString());
-					if (match.Success)
-					{
-						var min = match.Groups["min"].Value;
-						var max = match.Groups["max"].Value;
-						analysisBands.Add(new Models.AnalysisBand
-						{
-							MinimumMatchValue = Convert.ToInt32(min),
-							MaximumMatchValue = Convert.ToInt32(max)
-						});
-					}
-				}
 			}
-
-			return analysisBands;
 		}
-	}
-}

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/ImportBatchTask.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/BatchTasks/ImportBatchTask.cs
@@ -33,7 +33,7 @@ namespace Multilingual.Excel.FileType.BatchTasks
 		GeneratedFileType = AutomaticTaskFileType.BilingualTarget, AllowMultiple = true)]
 	[AutomaticTaskSupportedFileType(AutomaticTaskFileType.BilingualTarget)]
 	[RequiresSettings(typeof(MultilingualExcelImportSettings), typeof(ImportSettingsPage))]
-	public class ImportBatchTask : AbstractFileContentProcessingAutomaticTask
+	public class ImportBatchTask : BatchTaskBase
 	{
 		private MultilingualExcelImportSettings _settings;
 		private LanguageMappingSettings _languageMappingSettings;
@@ -82,18 +82,7 @@ namespace Multilingual.Excel.FileType.BatchTasks
 
 		private IPropertiesFactory propertiesFactory;
 
-		public override bool ShouldProcessFile(ProjectFile projectFile)
-		{
-			var valid = projectFile.FileTypeId == FiletypeConstants.FileTypeDefinitionId;
-			if (!valid)
-			{
-				var message = string.Format(PluginResources.ExceptionMessage_Incorrect_File_Type,
-					projectFile.FileTypeId, FiletypeConstants.FileTypeDefinitionId);
-				throw new Exception(message);
-			}
-
-			return true;
-		}
+		
 
 
 		private LanguageMapping _targetLanguageMapping = null;
@@ -218,17 +207,6 @@ namespace Multilingual.Excel.FileType.BatchTasks
 				// 2 c. Remove the translations and reset the segment status to not defined.
 				var sdlxliffUpdater = new SdlxliffUpdater(new ClearTranslationsContentProcessor());
 				UpdateFile(projectFile, sdlxliffUpdater);
-			}
-		}
-
-		private static void UpdateFile(ProjectFile projectFile, SdlxliffUpdater sdlxliffUpdater)
-		{
-			var updatedFilePath = Path.GetTempFileName();
-			sdlxliffUpdater.UpdateFile(projectFile.LocalFilePath, updatedFilePath);
-			File.Copy(updatedFilePath, projectFile.LocalFilePath, true);
-			if (File.Exists(updatedFilePath))
-			{
-				File.Delete(updatedFilePath);
 			}
 		}
 
@@ -673,33 +651,5 @@ namespace Multilingual.Excel.FileType.BatchTasks
 		}
 
 
-		private List<Models.AnalysisBand> GetAnalysisBands(FileBasedProject project)
-		{
-			var regex = new Regex(@"(?<min>[\d]*)([^\d]*)(?<max>[\d]*)", RegexOptions.IgnoreCase);
-
-			var analysisBands = new List<Models.AnalysisBand>();
-			var type = project.GetType();
-			var internalProjectField = type.GetField("_project", BindingFlags.NonPublic | BindingFlags.Instance);
-			if (internalProjectField != null)
-			{
-				dynamic internalDynamicProject = internalProjectField.GetValue(project);
-				foreach (var analysisBand in internalDynamicProject.AnalysisBands)
-				{
-					Match match = regex.Match(analysisBand.ToString());
-					if (match.Success)
-					{
-						var min = match.Groups["min"].Value;
-						var max = match.Groups["max"].Value;
-						analysisBands.Add(new Models.AnalysisBand
-						{
-							MinimumMatchValue = Convert.ToInt32(min),
-							MaximumMatchValue = Convert.ToInt32(max)
-						});
-					}
-				}
 			}
-
-			return analysisBands;
 		}
-	}
-}

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/Constants/FiletypeConstants.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/Constants/FiletypeConstants.cs
@@ -1,10 +1,17 @@
-﻿using System.Reflection;
-
-namespace Multilingual.Excel.FileType.Constants
+﻿namespace Multilingual.Excel.FileType.Constants
 {
 	public class FiletypeConstants
 	{
-		public static readonly string FileTypeDefinitionId = "Multilingual Excel FileType v " + Assembly.GetExecutingAssembly().GetName().Version;
+		// IMPORTANT: This identifier is persisted in user project files (.sdlproj, .sdlxliff)
+		// when a file is added to a Trados Studio project. It MUST remain stable across
+		// plugin releases, otherwise Studio will not recognize files created with previous
+		// versions of the plugin as belonging to this file type.
+		// Historically this string was built at runtime from Assembly.GetName().Version
+		// (e.g. "Multilingual Excel FileType v 3.0.0.0"). Legacy versioned IDs that exist
+		// in already-deployed projects are rewritten to this stable form on Studio startup
+		// and whenever a project is added (see FileTypeIdMigrationService).
+		// Do NOT change this string when bumping the assembly version.
+		public const string FileTypeDefinitionId = "Multilingual Excel FileType";
 		public const string FileTypeName = "Multilingual Excel";
 		public const string FileTypeDocumentName = "Multilingual Excel Document";
 		public const string FileTypeDocumentsName = "Multilingual Excel Documents";

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/Multilingual.Excel.FileType.csproj
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/Multilingual.Excel.FileType.csproj
@@ -80,6 +80,9 @@
 			<HintPath>$(TradosFolder)\Sdl.TellMe.ProviderApi.dll</HintPath>
 		</Reference>
 		<Reference Include="System.Configuration" />
+		<Reference Include="System.Reactive">
+		  <HintPath>$(TradosFolder)\System.Reactive.dll</HintPath>
+		</Reference>
 		<Reference Include="System.Web" />
 		<Reference Include="System.Data.DataSetExtensions" />
 		<Reference Include="Microsoft.CSharp" />

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/Properties/AssemblyInfo.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.2.0")]
+[assembly: AssemblyFileVersion("3.0.2.1")]

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/Services/FileTypeIdMigrationService.cs
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/Services/FileTypeIdMigrationService.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Sdl.ProjectAutomation.FileBased;
+
+namespace Multilingual.Excel.FileType.Services
+{
+    /// <summary>
+    /// Rewrites legacy versioned file type identifiers
+    /// (e.g. "Multilingual Excel FileType v 3.0.0.0") to the stable
+    /// "Multilingual Excel FileType" identifier inside Trados Studio
+    /// project files (.sdlproj) and bilingual files (.sdlxliff).
+    /// Only the trailing " v X.X.X.X" suffix is removed; the rest of the file
+    /// is preserved byte-for-byte (including original encoding/BOM and line endings).
+    /// The operation is idempotent: files without legacy IDs are not modified.
+    /// </summary>
+    internal class FileTypeIdMigrationService
+    {
+        // Strict match: exactly four dot-separated integer components.
+        // The first group ("Multilingual Excel FileType") is preserved by the
+        // replacement; only the " v X.X.X.X" suffix is dropped.
+        private const string LegacyIdPattern = @"(Multilingual Excel FileType) v \d+\.\d+\.\d+\.\d+";
+
+        private static readonly Regex LegacyIdRegex = new Regex(
+            LegacyIdPattern,
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        // Per-file dedup. A path is added only after the file was successfully
+        // read AND either rewritten or confirmed to not need rewriting. Files
+        // that fail (locked, IO error) are NOT recorded, so subsequent calls
+        // (triggered by ProjectsChanged / CurrentProjectChanging) will retry.
+        private readonly HashSet<string> _processedFilePaths =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Migrates the given project's .sdlproj and all .sdlxliff files under
+        /// its folder. Safe to call repeatedly: files that already succeeded are
+        /// skipped, files that previously failed (because they were locked) are
+        /// retried.
+        /// </summary>
+        public void MigrateProject(FileBasedProject project)
+        {
+            if (project == null)
+            {
+                return;
+            }
+
+            string projectFilePath;
+            try
+            {
+                projectFilePath = project.FilePath;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning("MultilingualExcel: cannot read project FilePath: {0}", ex.Message);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(projectFilePath) || !File.Exists(projectFilePath))
+            {
+                return;
+            }
+
+            TryMigrateFile(projectFilePath);
+
+            var projectFolder = Path.GetDirectoryName(projectFilePath);
+            if (string.IsNullOrEmpty(projectFolder) || !Directory.Exists(projectFolder))
+            {
+                return;
+            }
+
+            IEnumerable<string> sdlxliffFiles;
+            try
+            {
+                sdlxliffFiles = Directory.EnumerateFiles(projectFolder, "*.sdlxliff", SearchOption.AllDirectories);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning("MultilingualExcel: cannot enumerate sdlxliff files under '{0}': {1}", projectFolder, ex.Message);
+                return;
+            }
+
+            foreach (var sdlxliffFile in sdlxliffFiles)
+            {
+                TryMigrateFile(sdlxliffFile);
+            }
+        }
+
+        private void TryMigrateFile(string filePath)
+        {
+            if (_processedFilePaths.Contains(filePath))
+            {
+                return;
+            }
+
+            try
+            {
+                if (MigrateFile(filePath))
+                {
+                    _processedFilePaths.Add(filePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning("MultilingualExcel: failed to migrate '{0}': {1}", filePath, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Returns true when the file was processed deterministically (either rewritten
+        /// or confirmed to not need rewriting). Returns false when the file could not
+        /// be read/written due to a transient condition (e.g. Studio holds the file),
+        /// so the caller can retry later.
+        /// </summary>
+        private static bool MigrateFile(string filePath)
+        {
+            byte[] originalBytes;
+            try
+            {
+                // Use permissive sharing so we can read the file even when Studio
+                // has it open (Studio typically opens with FileShare.Read).
+                using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete))
+                {
+                    originalBytes = new byte[fs.Length];
+                    var offset = 0;
+                    while (offset < originalBytes.Length)
+                    {
+                        var read = fs.Read(originalBytes, offset, originalBytes.Length - offset);
+                        if (read <= 0)
+                        {
+                            break;
+                        }
+                        offset += read;
+                    }
+                }
+            }
+            catch (IOException ex)
+            {
+                // Likely in use exclusively by Studio; will retry later.
+                Trace.TraceInformation("MultilingualExcel: cannot read '{0}' yet (will retry): {1}", filePath, ex.Message);
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Trace.TraceInformation("MultilingualExcel: cannot read '{0}' yet (will retry): {1}", filePath, ex.Message);
+                return false;
+            }
+
+            Encoding encoding;
+            bool hasBom;
+            DetectEncoding(originalBytes, out encoding, out hasBom);
+
+            var preambleLength = hasBom ? encoding.GetPreamble().Length : 0;
+            var original = encoding.GetString(originalBytes, preambleLength, originalBytes.Length - preambleLength);
+
+            if (!LegacyIdRegex.IsMatch(original))
+            {
+                // Nothing to do; mark as processed so we don't keep re-reading it.
+                return true;
+            }
+
+            // "$1" keeps the captured "Multilingual Excel FileType" and drops the
+            // " v X.X.X.X" suffix. Nothing else in the file is touched.
+            var updated = LegacyIdRegex.Replace(original, "$1");
+            if (string.Equals(updated, original, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            byte[] updatedBytes;
+            if (hasBom)
+            {
+                var preamble = encoding.GetPreamble();
+                var contentBytes = encoding.GetBytes(updated);
+                updatedBytes = new byte[preamble.Length + contentBytes.Length];
+                Buffer.BlockCopy(preamble, 0, updatedBytes, 0, preamble.Length);
+                Buffer.BlockCopy(contentBytes, 0, updatedBytes, preamble.Length, contentBytes.Length);
+            }
+            else
+            {
+                updatedBytes = encoding.GetBytes(updated);
+            }
+
+            var tempPath = filePath + ".mlxmig.tmp";
+            try
+            {
+                File.WriteAllBytes(tempPath, updatedBytes);
+
+                // Atomic replace so a crash mid-write cannot truncate the original.
+                // This requires exclusive write access to filePath. If Studio holds
+                // an exclusive lock, this will throw and we return false so the
+                // caller can retry later (e.g. when the project is closed).
+                File.Replace(tempPath, filePath, null, ignoreMetadataErrors: true);
+                Trace.TraceInformation("MultilingualExcel: migrated legacy file type id in '{0}'.", filePath);
+                return true;
+            }
+            catch (IOException ex)
+            {
+                Trace.TraceInformation("MultilingualExcel: cannot rewrite '{0}' yet (will retry): {1}", filePath, ex.Message);
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Trace.TraceInformation("MultilingualExcel: cannot rewrite '{0}' yet (will retry): {1}", filePath, ex.Message);
+                return false;
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    try { File.Delete(tempPath); } catch { /* ignored */ }
+                }
+            }
+        }
+
+        private static void DetectEncoding(byte[] bytes, out Encoding encoding, out bool hasBom)
+        {
+            // UTF-8 BOM: EF BB BF
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            {
+                encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+                hasBom = true;
+                return;
+            }
+
+            // UTF-16 LE BOM: FF FE
+            if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+            {
+                encoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+                hasBom = true;
+                return;
+            }
+
+            // UTF-16 BE BOM: FE FF
+            if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+            {
+                encoding = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+                hasBom = true;
+                return;
+            }
+
+            // No BOM: assume UTF-8 (Studio's XML files are UTF-8 by default).
+            encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            hasBom = false;
+        }
+    }
+}

--- a/Multilingual Excel FileType/Multilingual.Excel.FileType/pluginpackage.manifest.xml
+++ b/Multilingual Excel FileType/Multilingual.Excel.FileType/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>Multilingual Excel FileType</PlugInName>
-	<Version>3.0.2.0</Version>
+	<Version>3.0.2.1</Version>
 	<Description>Multilingual Excel File Type</Description>
 	<Author>Trados AppStore Team</Author>
 	<RequiredProduct name="TradosStudio" minversion="19.0" maxversion="19.0.9"/>


### PR DESCRIPTION
Add MigrateLegacyFileTypeIdAction: removes the legacy version suffix (e.g. ' v 1.0.0.0') from references to the Multilingual Excel FileType in the selected project's .sdlproj and .sdlxliff files