### PR TITLE
Language Weaver 3.0.6.3 - DET-706: Fix tag placement in Language Weaver Cloud translations

### DIFF
--- a/Language Weaver Provider/LanguageWeaverProviderTests/LanguageWeaverProviderTests.csproj
+++ b/Language Weaver Provider/LanguageWeaverProviderTests/LanguageWeaverProviderTests.csproj
@@ -9,11 +9,13 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <Reference Include="Sdl.LanguagePlatform.Core">
       <HintPath>$(TradosFolder)\Sdl.LanguagePlatform.Core.dll</HintPath>
     </Reference>

--- a/Language Weaver Provider/LanguageWeaverProviderTests/PlainTextBatchTranslatorTests.cs
+++ b/Language Weaver Provider/LanguageWeaverProviderTests/PlainTextBatchTranslatorTests.cs
@@ -71,8 +71,8 @@ namespace LanguageWeaverProviderTests
             var engine = new RecordingTranslationEngine(inputs =>
             {
                 Assert.Single(inputs);
-                Assert.Equal("Click <lwtg0/>here", inputs[0]);
-                return new[] { "Klicke <lwtg0/>hier" };
+                Assert.Equal("Click <x id=\"0\"/>here", inputs[0]);
+                return new[] { "Klicke <x id=\"0\"/>hier" };
             });
 
             var translator = CreateTranslator(engine);

--- a/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
+++ b/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
@@ -33,7 +33,7 @@ namespace LanguageWeaverProviderTests
 
             var placer = new SegmentTagPlacer(segment);
 
-            Assert.Equal("Click <lwtg0/>here<lwtg1/>.", placer.PreparedText);
+            Assert.Equal("Click <x id=\"0\"/>here<x id=\"1\"/>.", placer.PreparedText);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace LanguageWeaverProviderTests
 
             var placer = new SegmentTagPlacer(segment);
 
-            Assert.Equal("<lwtg0/>a<lwtg1/>b<lwtg2/><lwtg3/>", placer.PreparedText);
+            Assert.Equal("<x id=\"0\"/>a<x id=\"1\"/>b<x id=\"2\"/>", placer.PreparedText);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace LanguageWeaverProviderTests
 
             var placer = new SegmentTagPlacer(source);
 
-            var target = placer.BuildTargetSegment("<lwtg0/>texte", TargetCulture);
+            var target = placer.BuildTargetSegment("<x id=\"0\"/>texte", TargetCulture);
 
             var emittedTag = target.Elements.OfType<Tag>().Single();
             Assert.Same(startTag, emittedTag);
@@ -92,7 +92,7 @@ namespace LanguageWeaverProviderTests
 
             var placer = new SegmentTagPlacer(source);
 
-            var target = placer.BuildTargetSegment("hallo<lwtg0/>", TargetCulture);
+            var target = placer.BuildTargetSegment("hallo<x id=\"0\"/>", TargetCulture);
 
             var elements = target.Elements;
             Assert.Equal(2, elements.Count);
@@ -113,7 +113,7 @@ namespace LanguageWeaverProviderTests
 
             var placer = new SegmentTagPlacer(source);
 
-            var target = placer.BuildTargetSegment("plain <lwtg0/>fett<lwtg1/>", TargetCulture);
+            var target = placer.BuildTargetSegment("plain <x id=\"0\"/>fett<x id=\"1\"/>", TargetCulture);
 
             var elements = target.Elements;
             Assert.Equal(4, elements.Count);
@@ -146,7 +146,7 @@ namespace LanguageWeaverProviderTests
             source.Add("hello");
             var placer = new SegmentTagPlacer(source);
 
-            var target = placer.BuildTargetSegment("hello <lwtg42/>world", TargetCulture);
+            var target = placer.BuildTargetSegment("hello <x id=\"42\"/>world", TargetCulture);
 
             Assert.False(target.HasTags);
             Assert.Equal("hello world", target.ToPlain());
@@ -200,6 +200,48 @@ namespace LanguageWeaverProviderTests
             Assert.Equal("here", ((Text)elements[2]).Value);
             Assert.Same(close, elements[3]);
             Assert.Equal(".", ((Text)elements[4]).Value);
+        }
+
+        [Fact]
+        public void PreparedText_TextWithXmlSpecialChars_IsEscaped()
+        {
+            var segment = new Segment();
+            segment.Add("a < b & c > d \"quote\"");
+
+            var placer = new SegmentTagPlacer(segment);
+
+            Assert.Equal("a &lt; b &amp; c &gt; d &quot;quote&quot;", placer.PreparedText);
+        }
+
+        [Fact]
+        public void BuildTargetSegment_EncodedTextSpan_IsDecoded()
+        {
+            var source = new Segment();
+            source.Add("dummy");
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("a &lt; b &amp; c &gt; d &quot;quote&quot;", TargetCulture);
+
+            Assert.Equal("a < b & c > d \"quote\"", target.ToPlain());
+        }
+
+        [Fact]
+        public void RoundTrip_TextWithXmlSpecialChars_PreservesOriginalText()
+        {
+            var tag = new Tag(TagType.Start, "1", 1);
+            var source = new Segment();
+            source.Add("a < b & c");
+            source.Add(tag);
+            source.Add(" \"d\" > e");
+
+            var placer = new SegmentTagPlacer(source);
+            var target = placer.BuildTargetSegment(placer.PreparedText, TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(3, elements.Count);
+            Assert.Equal("a < b & c", ((Text)elements[0]).Value);
+            Assert.Same(tag, elements[1]);
+            Assert.Equal(" \"d\" > e", ((Text)elements[2]).Value);
         }
     }
 }

--- a/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
+++ b/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
@@ -124,7 +124,7 @@ namespace LanguageWeaverProviderTests
         }
 
         [Fact]
-        public void BuildTargetSegment_DroppedStartPlaceholder_RestoresTagAtSegmentStart()
+        public void BuildTargetSegment_DroppedPlaceholder_OmitsTagWithoutThrowing()
         {
             var tag = new Tag(TagType.Start, "1", 1);
             var source = new Segment();
@@ -135,144 +135,8 @@ namespace LanguageWeaverProviderTests
 
             var target = placer.BuildTargetSegment("texte", TargetCulture);
 
-            var elements = target.Elements;
-            Assert.Equal(2, elements.Count);
-            Assert.Same(tag, elements[0]);
+            Assert.False(target.HasTags);
             Assert.Equal("texte", target.ToPlain());
-        }
-
-        [Fact]
-        public void BuildTargetSegment_DroppedEndPlaceholder_RestoresTagAtSegmentEnd()
-        {
-            var open = new Tag(TagType.Start, "1", 1);
-            var close = new Tag(TagType.End, "1", 1);
-            var source = new Segment();
-            source.Add(open);
-            source.Add("bold");
-            source.Add(close);
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("<x id=\"0\"/>fett gedruckt", TargetCulture);
-
-            var elements = target.Elements;
-            Assert.Equal(3, elements.Count);
-            Assert.Same(open, elements[0]);
-            Assert.Equal("fett gedruckt", ((Text)elements[1]).Value);
-            Assert.Same(close, elements[2]);
-        }
-
-        [Fact]
-        public void BuildTargetSegment_AllPlaceholdersDropped_WrapsTranslationInTagPair()
-        {
-            var open = new Tag(TagType.Start, "1", 1);
-            var close = new Tag(TagType.End, "1", 1);
-            var source = new Segment();
-            source.Add(open);
-            source.Add("bold");
-            source.Add(close);
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("fett", TargetCulture);
-
-            var elements = target.Elements;
-            Assert.Equal(3, elements.Count);
-            Assert.Same(open, elements[0]);
-            Assert.Equal("fett", ((Text)elements[1]).Value);
-            Assert.Same(close, elements[2]);
-        }
-
-        [Fact]
-        public void BuildTargetSegment_DroppedStartPlaceholder_InsertsStartBeforeItsEnd()
-        {
-            var open = new Tag(TagType.Start, "1", 1);
-            var close = new Tag(TagType.End, "1", 1);
-            var source = new Segment();
-            source.Add(open);
-            source.Add("bold");
-            source.Add(close);
-            source.Add(" plain");
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("fett<x id=\"1\"/> einfach", TargetCulture);
-
-            var elements = target.Elements;
-            Assert.Equal(4, elements.Count);
-            Assert.Same(open, elements[0]);
-            Assert.Equal("fett", ((Text)elements[1]).Value);
-            Assert.Same(close, elements[2]);
-            Assert.Equal(" einfach", ((Text)elements[3]).Value);
-        }
-
-        [Fact]
-        public void BuildTargetSegment_PlaceholderWithoutSelfClosingSlash_IsRecognized()
-        {
-            var tag = new Tag(TagType.Start, "1", 1);
-            var source = new Segment();
-            source.Add(tag);
-            source.Add("text");
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("<x id=\"0\">texte", TargetCulture);
-
-            var elements = target.Elements;
-            Assert.Equal(2, elements.Count);
-            Assert.Same(tag, elements[0]);
-            Assert.Equal("texte", target.ToPlain());
-        }
-
-        [Fact]
-        public void BuildTargetSegment_PlaceholderWithUnquotedId_IsRecognized()
-        {
-            var tag = new Tag(TagType.Start, "1", 1);
-            var source = new Segment();
-            source.Add(tag);
-            source.Add("text");
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("<x id=0/>texte", TargetCulture);
-
-            Assert.Same(tag, target.Elements[0]);
-            Assert.Equal("texte", target.ToPlain());
-        }
-
-        [Fact]
-        public void BuildTargetSegment_HtmlizedPlaceholderWithCloser_StripsCloser()
-        {
-            var tag = new Tag(TagType.Start, "1", 1);
-            var source = new Segment();
-            source.Add(tag);
-            source.Add("text");
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("<x id=\"0\">texte</x>", TargetCulture);
-
-            var elements = target.Elements;
-            Assert.Equal(2, elements.Count);
-            Assert.Same(tag, elements[0]);
-            Assert.Equal("texte", target.ToPlain());
-        }
-
-        [Fact]
-        public void BuildTargetSegment_RepeatedPlaceholder_EmitsTagOnlyOnce()
-        {
-            var tag = new Tag(TagType.Start, "1", 1);
-            var source = new Segment();
-            source.Add(tag);
-            source.Add("text");
-
-            var placer = new SegmentTagPlacer(source);
-
-            var target = placer.BuildTargetSegment("<x id=\"0\"/>a<x id=\"0\"/>b", TargetCulture);
-
-            Assert.Single(target.Elements.OfType<Tag>());
-            Assert.Same(tag, target.Elements[0]);
-            Assert.Equal("ab", target.ToPlain());
         }
 
         [Fact]

--- a/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
+++ b/Language Weaver Provider/LanguageWeaverProviderTests/SegmentTagPlacerTests.cs
@@ -124,7 +124,7 @@ namespace LanguageWeaverProviderTests
         }
 
         [Fact]
-        public void BuildTargetSegment_DroppedPlaceholder_OmitsTagWithoutThrowing()
+        public void BuildTargetSegment_DroppedStartPlaceholder_RestoresTagAtSegmentStart()
         {
             var tag = new Tag(TagType.Start, "1", 1);
             var source = new Segment();
@@ -135,8 +135,144 @@ namespace LanguageWeaverProviderTests
 
             var target = placer.BuildTargetSegment("texte", TargetCulture);
 
-            Assert.False(target.HasTags);
+            var elements = target.Elements;
+            Assert.Equal(2, elements.Count);
+            Assert.Same(tag, elements[0]);
             Assert.Equal("texte", target.ToPlain());
+        }
+
+        [Fact]
+        public void BuildTargetSegment_DroppedEndPlaceholder_RestoresTagAtSegmentEnd()
+        {
+            var open = new Tag(TagType.Start, "1", 1);
+            var close = new Tag(TagType.End, "1", 1);
+            var source = new Segment();
+            source.Add(open);
+            source.Add("bold");
+            source.Add(close);
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("<x id=\"0\"/>fett gedruckt", TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(3, elements.Count);
+            Assert.Same(open, elements[0]);
+            Assert.Equal("fett gedruckt", ((Text)elements[1]).Value);
+            Assert.Same(close, elements[2]);
+        }
+
+        [Fact]
+        public void BuildTargetSegment_AllPlaceholdersDropped_WrapsTranslationInTagPair()
+        {
+            var open = new Tag(TagType.Start, "1", 1);
+            var close = new Tag(TagType.End, "1", 1);
+            var source = new Segment();
+            source.Add(open);
+            source.Add("bold");
+            source.Add(close);
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("fett", TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(3, elements.Count);
+            Assert.Same(open, elements[0]);
+            Assert.Equal("fett", ((Text)elements[1]).Value);
+            Assert.Same(close, elements[2]);
+        }
+
+        [Fact]
+        public void BuildTargetSegment_DroppedStartPlaceholder_InsertsStartBeforeItsEnd()
+        {
+            var open = new Tag(TagType.Start, "1", 1);
+            var close = new Tag(TagType.End, "1", 1);
+            var source = new Segment();
+            source.Add(open);
+            source.Add("bold");
+            source.Add(close);
+            source.Add(" plain");
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("fett<x id=\"1\"/> einfach", TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(4, elements.Count);
+            Assert.Same(open, elements[0]);
+            Assert.Equal("fett", ((Text)elements[1]).Value);
+            Assert.Same(close, elements[2]);
+            Assert.Equal(" einfach", ((Text)elements[3]).Value);
+        }
+
+        [Fact]
+        public void BuildTargetSegment_PlaceholderWithoutSelfClosingSlash_IsRecognized()
+        {
+            var tag = new Tag(TagType.Start, "1", 1);
+            var source = new Segment();
+            source.Add(tag);
+            source.Add("text");
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("<x id=\"0\">texte", TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(2, elements.Count);
+            Assert.Same(tag, elements[0]);
+            Assert.Equal("texte", target.ToPlain());
+        }
+
+        [Fact]
+        public void BuildTargetSegment_PlaceholderWithUnquotedId_IsRecognized()
+        {
+            var tag = new Tag(TagType.Start, "1", 1);
+            var source = new Segment();
+            source.Add(tag);
+            source.Add("text");
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("<x id=0/>texte", TargetCulture);
+
+            Assert.Same(tag, target.Elements[0]);
+            Assert.Equal("texte", target.ToPlain());
+        }
+
+        [Fact]
+        public void BuildTargetSegment_HtmlizedPlaceholderWithCloser_StripsCloser()
+        {
+            var tag = new Tag(TagType.Start, "1", 1);
+            var source = new Segment();
+            source.Add(tag);
+            source.Add("text");
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("<x id=\"0\">texte</x>", TargetCulture);
+
+            var elements = target.Elements;
+            Assert.Equal(2, elements.Count);
+            Assert.Same(tag, elements[0]);
+            Assert.Equal("texte", target.ToPlain());
+        }
+
+        [Fact]
+        public void BuildTargetSegment_RepeatedPlaceholder_EmitsTagOnlyOnce()
+        {
+            var tag = new Tag(TagType.Start, "1", 1);
+            var source = new Segment();
+            source.Add(tag);
+            source.Add("text");
+
+            var placer = new SegmentTagPlacer(source);
+
+            var target = placer.BuildTargetSegment("<x id=\"0\"/>a<x id=\"0\"/>b", TargetCulture);
+
+            Assert.Single(target.Elements.OfType<Tag>());
+            Assert.Same(tag, target.Elements[0]);
+            Assert.Equal("ab", target.ToPlain());
         }
 
         [Fact]

--- a/Language Weaver Provider/Properties/AssemblyInfo.cs
+++ b/Language Weaver Provider/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.6.2")]
+[assembly: AssemblyFileVersion("3.0.6.3")]

--- a/Language Weaver Provider/Services/CloudService.cs
+++ b/Language Weaver Provider/Services/CloudService.cs
@@ -271,6 +271,7 @@ namespace LanguageWeaverProvider.Services
                 SourceLanguageId = mappedPair.SourceCode,
                 TargetLanguageId = mappedPair.TargetCode,
                 Input = plainTextSegments,
+                InputFormat = "HTML",
                 Model = mappedPair.SelectedModel.Model,
                 Dictionaries = dictionaries,
                 LinguisticOptions = linguisticOptionsDictionary,

--- a/Language Weaver Provider/Services/Model/CloudTranslationRequest.cs
+++ b/Language Weaver Provider/Services/Model/CloudTranslationRequest.cs
@@ -10,6 +10,9 @@ namespace LanguageWeaverProvider.Services.Model
 
 		[JsonProperty("input")]
 		public string[] Input { get; set; }
+        
+        [JsonProperty("inputFormat")]
+		public string InputFormat { get; set; }
 
 		[JsonProperty("model")]
 		public string Model { get; set; }

--- a/Language Weaver Provider/Services/Model/EdgeTranslationRequestContent.cs
+++ b/Language Weaver Provider/Services/Model/EdgeTranslationRequestContent.cs
@@ -7,9 +7,9 @@ namespace LanguageWeaverProvider.Services.Model
 {
 	public class EdgeTranslationRequestContent
 	{
-		const string PlainTextMimeType = "text/plain";
+        const string PlainTextMimeType = "text/html";
 
-		public EdgeTranslationRequestContent(PairMapping pairMapping, string input)
+        public EdgeTranslationRequestContent(PairMapping pairMapping, string input)
 		{
 			LanguagePairId = pairMapping.SelectedModel.Model;
 			Input = input;

--- a/Language Weaver Provider/Services/SegmentTagPlacer.cs
+++ b/Language Weaver Provider/Services/SegmentTagPlacer.cs
@@ -1,6 +1,7 @@
 using Sdl.Core.Globalization;
 using Sdl.LanguagePlatform.Core;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -10,7 +11,7 @@ namespace LanguageWeaverProvider.Services
     /// <summary>
     /// Prepares an SDL <see cref="Segment"/> for translation by replacing inline
     /// <see cref="Tag"/> elements with XLIFF 1.2 self-closing placeholders
-    /// (<c>&lt;x id="N"/&gt;</c>) that Language Weaver preserves verbatim when the
+    /// (<c>&lt;x id="N"/&gt;</c>) that Language Weaver preserves when the
     /// request's input format is HTML. Text content is HTML-encoded before sending
     /// and decoded on the way back.
     ///
@@ -18,12 +19,20 @@ namespace LanguageWeaverProvider.Services
     /// the API never receives two placeholders with no text between them (which
     /// would cause it to insert spurious spaces). The original tag objects are
     /// kept so the translated text can be rehydrated into a target <see cref="Segment"/>.
+    ///
+    /// Because <c>x</c> is not an HTML void element, the engine may echo a
+    /// placeholder back in a different serialization (<c>&lt;x id="0"&gt;</c>,
+    /// <c>&lt;x id=0/&gt;</c>, a separate <c>&lt;/x&gt;</c> close, ...), repeat it,
+    /// or drop it altogether. Rehydration therefore matches placeholders leniently,
+    /// honours only the first occurrence of each, and re-inserts dropped tag groups
+    /// at the closest position that keeps the groups in source order, so tags are
+    /// never lost and start/end pairs stay correctly nested.
     /// </summary>
     public sealed class SegmentTagPlacer
     {
         private static readonly Regex PlaceholderRegex = new(
-            @"<x\s+id\s*=\s*[""'](\d+)[""']\s*/>",
-            RegexOptions.Compiled);
+            @"<x\s+id\s*=\s*[""']?(?<id>\d+)[""']?\s*/?\s*>|</x\s*>",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Each entry is a group of one-or-more consecutive source tags that were
         // collapsed into a single <x id="N"/> placeholder.
@@ -38,21 +47,49 @@ namespace LanguageWeaverProvider.Services
             var segment = new Segment(targetCulture);
             if (string.IsNullOrEmpty(translatedText)) return segment;
 
+            var items = ParseTranslatedText(translatedText);
+            InsertMissingTagGroups(items);
+
+            foreach (var item in items)
+            {
+                if (item is int groupIndex)
+                {
+                    foreach (var tag in _tagGroups[groupIndex])
+                        segment.Add(tag);
+                }
+                else if (item is string text && text.Length > 0)
+                {
+                    segment.Add(WebUtility.HtmlDecode(text));
+                }
+            }
+
+            return segment;
+        }
+
+        // Splits the translated text into a flat list of items: text runs (string)
+        // and recognized tag-group placeholders (int). Unknown ids, repeated ids
+        // and stray </x> closers are dropped from the output entirely.
+        private List<object> ParseTranslatedText(string translatedText)
+        {
+            var items = new List<object>();
+            var seenGroups = new HashSet<int>();
             var lastIndex = 0;
+
             foreach (Match match in PlaceholderRegex.Matches(translatedText))
             {
                 if (match.Index > lastIndex)
                 {
-                    var leadingText = translatedText.Substring(lastIndex, match.Index - lastIndex);
-                    if (leadingText.Length > 0) segment.Add(WebUtility.HtmlDecode(leadingText));
+                    items.Add(translatedText.Substring(lastIndex, match.Index - lastIndex));
                 }
 
-                if (int.TryParse(match.Groups[1].Value, out var groupIndex)
+                var id = match.Groups["id"];
+                if (id.Success
+                    && int.TryParse(id.Value, out var groupIndex)
                     && groupIndex >= 0
-                    && groupIndex < _tagGroups.Count)
+                    && groupIndex < _tagGroups.Count
+                    && seenGroups.Add(groupIndex))
                 {
-                    foreach (var tag in _tagGroups[groupIndex])
-                        segment.Add(tag);
+                    items.Add(groupIndex);
                 }
 
                 lastIndex = match.Index + match.Length;
@@ -60,11 +97,43 @@ namespace LanguageWeaverProvider.Services
 
             if (lastIndex < translatedText.Length)
             {
-                var trailingText = translatedText.Substring(lastIndex);
-                if (trailingText.Length > 0) segment.Add(WebUtility.HtmlDecode(trailingText));
+                items.Add(translatedText.Substring(lastIndex));
             }
 
-            return segment;
+            return items;
+        }
+
+        // Re-inserts tag groups whose placeholders the engine did not echo back.
+        // Each missing group goes between the placed groups with smaller and larger
+        // indices: start-only groups as early as that window allows (so they open
+        // before their pair closes), every other group as late as it allows.
+        private void InsertMissingTagGroups(List<object> items)
+        {
+            for (var groupIndex = 0; groupIndex < _tagGroups.Count; groupIndex++)
+            {
+                if (items.Contains(groupIndex)) continue;
+
+                var lowerBound = 0;
+                var upperBound = items.Count;
+                for (var i = 0; i < items.Count; i++)
+                {
+                    if (items[i] is not int placedGroup) continue;
+                    if (placedGroup < groupIndex)
+                    {
+                        lowerBound = i + 1;
+                    }
+                    else
+                    {
+                        upperBound = i;
+                        break;
+                    }
+                }
+
+                if (upperBound < lowerBound) upperBound = lowerBound;
+
+                var startTagsOnly = _tagGroups[groupIndex].All(tag => tag.Type == TagType.Start);
+                items.Insert(startTagsOnly ? lowerBound : upperBound, groupIndex);
+            }
         }
 
         private string BuildPreparedText(Segment sourceSegment)

--- a/Language Weaver Provider/Services/SegmentTagPlacer.cs
+++ b/Language Weaver Provider/Services/SegmentTagPlacer.cs
@@ -1,26 +1,33 @@
 using Sdl.Core.Globalization;
 using Sdl.LanguagePlatform.Core;
 using System.Collections.Generic;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 
 namespace LanguageWeaverProvider.Services
 {
     /// <summary>
-    /// Prepares an SDL <see cref="Segment"/> for plain-text translation by replacing each
-    /// inline <see cref="Tag"/> with a numbered XML-style placeholder that the MT engine
-    /// is expected to preserve verbatim. The original tag objects are kept in order so the
-    /// translated text can be rehydrated into a target <see cref="Segment"/>.
+    /// Prepares an SDL <see cref="Segment"/> for translation by replacing inline
+    /// <see cref="Tag"/> elements with XLIFF 1.2 self-closing placeholders
+    /// (<c>&lt;x id="N"/&gt;</c>) that Language Weaver preserves verbatim when the
+    /// request's input format is HTML. Text content is HTML-encoded before sending
+    /// and decoded on the way back.
+    ///
+    /// Consecutive adjacent tags are collapsed into a single placeholder so that
+    /// the API never receives two placeholders with no text between them (which
+    /// would cause it to insert spurious spaces). The original tag objects are
+    /// kept so the translated text can be rehydrated into a target <see cref="Segment"/>.
     /// </summary>
     public sealed class SegmentTagPlacer
     {
-        private const string PlaceholderPrefix = "lwtg";
-
         private static readonly Regex PlaceholderRegex = new(
-            @"<" + PlaceholderPrefix + @"(\d+)\s*/?>",
+            @"<x\s+id\s*=\s*[""'](\d+)[""']\s*/>",
             RegexOptions.Compiled);
 
-        private readonly List<Tag> _tagsByIndex = new();
+        // Each entry is a group of one-or-more consecutive source tags that were
+        // collapsed into a single <x id="N"/> placeholder.
+        private readonly List<List<Tag>> _tagGroups = new();
 
         public SegmentTagPlacer(Segment sourceSegment) => PreparedText = BuildPreparedText(sourceSegment);
 
@@ -37,20 +44,25 @@ namespace LanguageWeaverProvider.Services
                 if (match.Index > lastIndex)
                 {
                     var leadingText = translatedText.Substring(lastIndex, match.Index - lastIndex);
-                    if (leadingText.Length > 0) segment.Add(leadingText);
+                    if (leadingText.Length > 0) segment.Add(WebUtility.HtmlDecode(leadingText));
                 }
 
-                if (int.TryParse(match.Groups[1].Value, out var tagIndex)
-                    && tagIndex >= 0
-                    && tagIndex < _tagsByIndex.Count) segment.Add(_tagsByIndex[tagIndex]);
+                if (int.TryParse(match.Groups[1].Value, out var groupIndex)
+                    && groupIndex >= 0
+                    && groupIndex < _tagGroups.Count)
+                {
+                    foreach (var tag in _tagGroups[groupIndex])
+                        segment.Add(tag);
+                }
 
                 lastIndex = match.Index + match.Length;
             }
 
-            if (lastIndex >= translatedText.Length) return segment;
-
-            var trailingText = translatedText.Substring(lastIndex);
-            if (trailingText.Length > 0) segment.Add(trailingText);
+            if (lastIndex < translatedText.Length)
+            {
+                var trailingText = translatedText.Substring(lastIndex);
+                if (trailingText.Length > 0) segment.Add(WebUtility.HtmlDecode(trailingText));
+            }
 
             return segment;
         }
@@ -58,20 +70,31 @@ namespace LanguageWeaverProvider.Services
         private string BuildPreparedText(Segment sourceSegment)
         {
             var builder = new StringBuilder();
+            var pendingGroup = new List<Tag>();
+
             foreach (var element in sourceSegment.Elements)
             {
                 if (element is Tag tag)
                 {
-                    var placeholderIndex = _tagsByIndex.Count;
-                    _tagsByIndex.Add(tag);
-                    builder.Append('<').Append(PlaceholderPrefix).Append(placeholderIndex).Append("/>");
+                    pendingGroup.Add(tag);
                     continue;
                 }
 
-                builder.Append(element);
+                FlushTagGroup(builder, pendingGroup);
+                builder.Append(WebUtility.HtmlEncode(element.ToString()));
             }
 
+            FlushTagGroup(builder, pendingGroup);
             return builder.ToString();
+        }
+
+        private void FlushTagGroup(StringBuilder builder, List<Tag> pendingGroup)
+        {
+            if (pendingGroup.Count == 0) return;
+            var groupIndex = _tagGroups.Count;
+            _tagGroups.Add(new List<Tag>(pendingGroup));
+            pendingGroup.Clear();
+            builder.Append("<x id=\"").Append(groupIndex).Append("\"/>");
         }
     }
 }

--- a/Language Weaver Provider/Services/SegmentTagPlacer.cs
+++ b/Language Weaver Provider/Services/SegmentTagPlacer.cs
@@ -1,7 +1,6 @@
 using Sdl.Core.Globalization;
 using Sdl.LanguagePlatform.Core;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,7 +10,7 @@ namespace LanguageWeaverProvider.Services
     /// <summary>
     /// Prepares an SDL <see cref="Segment"/> for translation by replacing inline
     /// <see cref="Tag"/> elements with XLIFF 1.2 self-closing placeholders
-    /// (<c>&lt;x id="N"/&gt;</c>) that Language Weaver preserves when the
+    /// (<c>&lt;x id="N"/&gt;</c>) that Language Weaver preserves verbatim when the
     /// request's input format is HTML. Text content is HTML-encoded before sending
     /// and decoded on the way back.
     ///
@@ -19,20 +18,12 @@ namespace LanguageWeaverProvider.Services
     /// the API never receives two placeholders with no text between them (which
     /// would cause it to insert spurious spaces). The original tag objects are
     /// kept so the translated text can be rehydrated into a target <see cref="Segment"/>.
-    ///
-    /// Because <c>x</c> is not an HTML void element, the engine may echo a
-    /// placeholder back in a different serialization (<c>&lt;x id="0"&gt;</c>,
-    /// <c>&lt;x id=0/&gt;</c>, a separate <c>&lt;/x&gt;</c> close, ...), repeat it,
-    /// or drop it altogether. Rehydration therefore matches placeholders leniently,
-    /// honours only the first occurrence of each, and re-inserts dropped tag groups
-    /// at the closest position that keeps the groups in source order, so tags are
-    /// never lost and start/end pairs stay correctly nested.
     /// </summary>
     public sealed class SegmentTagPlacer
     {
         private static readonly Regex PlaceholderRegex = new(
-            @"<x\s+id\s*=\s*[""']?(?<id>\d+)[""']?\s*/?\s*>|</x\s*>",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            @"<x\s+id\s*=\s*[""'](\d+)[""']\s*/>",
+            RegexOptions.Compiled);
 
         // Each entry is a group of one-or-more consecutive source tags that were
         // collapsed into a single <x id="N"/> placeholder.
@@ -47,49 +38,21 @@ namespace LanguageWeaverProvider.Services
             var segment = new Segment(targetCulture);
             if (string.IsNullOrEmpty(translatedText)) return segment;
 
-            var items = ParseTranslatedText(translatedText);
-            InsertMissingTagGroups(items);
-
-            foreach (var item in items)
-            {
-                if (item is int groupIndex)
-                {
-                    foreach (var tag in _tagGroups[groupIndex])
-                        segment.Add(tag);
-                }
-                else if (item is string text && text.Length > 0)
-                {
-                    segment.Add(WebUtility.HtmlDecode(text));
-                }
-            }
-
-            return segment;
-        }
-
-        // Splits the translated text into a flat list of items: text runs (string)
-        // and recognized tag-group placeholders (int). Unknown ids, repeated ids
-        // and stray </x> closers are dropped from the output entirely.
-        private List<object> ParseTranslatedText(string translatedText)
-        {
-            var items = new List<object>();
-            var seenGroups = new HashSet<int>();
             var lastIndex = 0;
-
             foreach (Match match in PlaceholderRegex.Matches(translatedText))
             {
                 if (match.Index > lastIndex)
                 {
-                    items.Add(translatedText.Substring(lastIndex, match.Index - lastIndex));
+                    var leadingText = translatedText.Substring(lastIndex, match.Index - lastIndex);
+                    if (leadingText.Length > 0) segment.Add(WebUtility.HtmlDecode(leadingText));
                 }
 
-                var id = match.Groups["id"];
-                if (id.Success
-                    && int.TryParse(id.Value, out var groupIndex)
+                if (int.TryParse(match.Groups[1].Value, out var groupIndex)
                     && groupIndex >= 0
-                    && groupIndex < _tagGroups.Count
-                    && seenGroups.Add(groupIndex))
+                    && groupIndex < _tagGroups.Count)
                 {
-                    items.Add(groupIndex);
+                    foreach (var tag in _tagGroups[groupIndex])
+                        segment.Add(tag);
                 }
 
                 lastIndex = match.Index + match.Length;
@@ -97,43 +60,11 @@ namespace LanguageWeaverProvider.Services
 
             if (lastIndex < translatedText.Length)
             {
-                items.Add(translatedText.Substring(lastIndex));
+                var trailingText = translatedText.Substring(lastIndex);
+                if (trailingText.Length > 0) segment.Add(WebUtility.HtmlDecode(trailingText));
             }
 
-            return items;
-        }
-
-        // Re-inserts tag groups whose placeholders the engine did not echo back.
-        // Each missing group goes between the placed groups with smaller and larger
-        // indices: start-only groups as early as that window allows (so they open
-        // before their pair closes), every other group as late as it allows.
-        private void InsertMissingTagGroups(List<object> items)
-        {
-            for (var groupIndex = 0; groupIndex < _tagGroups.Count; groupIndex++)
-            {
-                if (items.Contains(groupIndex)) continue;
-
-                var lowerBound = 0;
-                var upperBound = items.Count;
-                for (var i = 0; i < items.Count; i++)
-                {
-                    if (items[i] is not int placedGroup) continue;
-                    if (placedGroup < groupIndex)
-                    {
-                        lowerBound = i + 1;
-                    }
-                    else
-                    {
-                        upperBound = i;
-                        break;
-                    }
-                }
-
-                if (upperBound < lowerBound) upperBound = lowerBound;
-
-                var startTagsOnly = _tagGroups[groupIndex].All(tag => tag.Type == TagType.Start);
-                items.Insert(startTagsOnly ? lowerBound : upperBound, groupIndex);
-            }
+            return segment;
         }
 
         private string BuildPreparedText(Segment sourceSegment)

--- a/Language Weaver Provider/pluginpackage.manifest.xml
+++ b/Language Weaver Provider/pluginpackage.manifest.xml
@@ -5,7 +5,7 @@
 	<PlugInName>Language Weaver Provider</PlugInName>
 	<Description>Language Weaver Provider</Description>
 
-	<Version>3.0.6.2</Version>
+	<Version>3.0.6.3</Version>
 	<RequiredProduct name="TradosStudio" minversion="19.0" maxversion="19.0.9" />
 
 	<Include>


### PR DESCRIPTION
Group consecutive inline tags into a single placeholder before sending to the API, and switch inputFormat to HTML to prevent tag misplacement in translated output.
